### PR TITLE
Fix lint quality gate

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,W503

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
           enable-cache: true
       - name: Install project dependencies
         run: uv sync --locked --group dev
+      - name: Run lint
+        run: make lint
       - name: Run tests
         run: uv run pytest tests/
       - name: Prune uv cache

--- a/example/current_time_demo.py
+++ b/example/current_time_demo.py
@@ -14,12 +14,12 @@ from use_notify.channels.base import BaseChannel
 class DemoChannel(BaseChannel):
     def __init__(self):
         super().__init__({})
-    
+
     def send(self, content, title=None):
         print(f"📧 通知标题: {title}")
         print(f"📝 通知内容: {content}")
         print("-" * 50)
-    
+
     async def send_async(self, content, title=None):
         self.send(content, title)
 
@@ -28,7 +28,7 @@ def main():
     # 创建通知实例
     demo_channel = DemoChannel()
     notify_instance = useNotify([demo_channel])
-    
+
     # 使用包含当前时间的自定义模板
     success_template = (
         "✅ 函数 {function_name} 执行成功\n"
@@ -37,7 +37,7 @@ def main():
         "🕐 结束时间: {end_time}\n"
         "🕐 通知时间: {current_time}"
     )
-    
+
     error_template = (
         "❌ 函数 {function_name} 执行失败\n"
         "⏱️ 执行时间: {execution_time:.2f}秒\n"
@@ -46,45 +46,45 @@ def main():
         "🕐 通知时间: {current_time}\n"
         "🚨 错误信息: {error_message}"
     )
-    
+
     # 使用装饰器和自定义模板
     from use_notify.decorator import notify
-    
+
     @notify(
         notify_instance=notify_instance,
         success_template=success_template,
-        error_template=error_template
+        error_template=error_template,
     )
     def successful_task():
         """一个成功的任务"""
         print("正在执行任务...")
         time.sleep(1)  # 模拟任务执行
         return "任务完成"
-    
+
     @notify(
         notify_instance=notify_instance,
         success_template=success_template,
-        error_template=error_template
+        error_template=error_template,
     )
     def failing_task():
         """一个失败的任务"""
         print("正在执行任务...")
         time.sleep(0.5)  # 模拟任务执行
         raise ValueError("模拟的错误")
-    
+
     print("=== 演示成功任务通知 ===")
     try:
         result = successful_task()
         print(f"任务结果: {result}")
     except Exception as e:
         print(f"任务失败: {e}")
-    
+
     print("\n=== 演示失败任务通知 ===")
     try:
         failing_task()
     except Exception as e:
         print(f"任务失败: {e}")
-    
+
     print("\n=== 说明 ===")
     print("在上面的通知中，你可以看到:")
     print("- start_time: 函数开始执行的时间")

--- a/example/decorator_default_instance.py
+++ b/example/decorator_default_instance.py
@@ -13,31 +13,33 @@ import sys
 import time
 
 # 添加项目根目录到Python路径
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from use_notify import (
-    useNotify, 
-    notify, 
-    set_default_notify_instance,
+    clear_default_notify_instance,
     get_default_notify_instance,
-    clear_default_notify_instance
+    notify,
+    set_default_notify_instance,
+    useNotify,
 )
-from use_notify.channels.console import Console as ConsoleChannel
 from use_notify.channels.base import BaseChannel
+from use_notify.channels.console import Console as ConsoleChannel
+
 
 def setup_default_notify_instance():
     """设置全局默认通知实例"""
     print("🔧 设置全局默认通知实例...")
-    
+
     # 创建通知实例
     default_notify = useNotify()
     default_notify.add(ConsoleChannel())
-    
+
     # 设置为全局默认实例
     set_default_notify_instance(default_notify)
-    
+
     print("✅ 全局默认通知实例设置完成")
     return default_notify
+
 
 setup_default_notify_instance()
 
@@ -62,7 +64,7 @@ def process_data(count):
     title="高级任务",
     success_template="🎯 {function_name} 完成\n📊 参数: {args}\n⏱️ 耗时: {execution_time:.2f}秒\n📋 结果: {result}",
     include_args=True,
-    include_result=True
+    include_result=True,
 )
 def advanced_task(task_type, priority="normal"):
     """高级任务 - 使用默认实例和自定义模板"""
@@ -73,18 +75,19 @@ def advanced_task(task_type, priority="normal"):
 
 @notify(
     notify_on_success=False,  # 只在失败时通知
-    error_template="🚨 监控告警\n🖥️ 服务: {args[0]}\n❗ 错误: {error_message}"
+    error_template="🚨 监控告警\n🖥️ 服务: {args[0]}\n❗ 错误: {error_message}",
 )
 def health_check(service_name):
     """健康检查 - 只在失败时使用默认实例通知"""
     print(f"检查服务: {service_name}")
     time.sleep(0.5)
-    
+
     # 模拟随机失败
     import random
+
     if random.random() < 0.3:  # 30% 失败率
         raise RuntimeError(f"{service_name} 服务异常")
-    
+
     return f"{service_name} 服务正常"
 
 
@@ -100,35 +103,35 @@ async def async_download(url):
 def demo_override_instance():
     """演示如何在特定装饰器中覆盖默认实例"""
     print("\n=== 覆盖默认实例演示 ===")
-    
+
     # 创建另一个通知实例
     class SpecialChannel(BaseChannel):
         def __init__(self, config=None):
             super().__init__(config or {})
-        
+
         def send(self, content, title=None):
             print(f"\n🔥 [特殊通知] {title}")
             print(f"🔥 {content}")
             print("=" * 50)
-        
+
         async def send_async(self, content, title=None):
             print(f"\n🔥 [特殊异步通知] {title}")
             print(f"🔥 {content}")
             print("=" * 50)
-    
+
     special_notify = useNotify()
     special_notify.add(SpecialChannel())
-    
+
     # 使用特定的通知实例（覆盖默认实例）
     @notify(
         notify_instance=special_notify,
         title="特殊任务",
-        success_template="🌟 特殊任务 {function_name} 完成"
+        success_template="🌟 特殊任务 {function_name} 完成",
     )
     def special_task():
         time.sleep(1)
         return "特殊任务完成"
-    
+
     print("执行特殊任务（使用特定通知实例）...")
     result = special_task()
     print(f"结果: {result}")
@@ -138,27 +141,27 @@ def main():
     """主函数"""
     print("🚀 @notify 装饰器全局默认实例演示")
     print("=" * 60)
-    
+
     print(f"\n📋 当前默认实例: {get_default_notify_instance()}")
-    
+
     # 2. 使用默认实例的基础示例
     print("\n=== 基础使用（无需传递 notify_instance）===")
     print("执行简单任务...")
     result = simple_task()
     print(f"结果: {result}")
-    
+
     # 3. 使用默认实例的自定义配置
     print("\n=== 自定义配置（使用默认实例）===")
     print("执行数据处理任务...")
     result = process_data(1000)
     print(f"结果: {result}")
-    
+
     # 4. 高级配置示例
     print("\n=== 高级配置（使用默认实例）===")
     print("执行高级任务...")
     result = advanced_task("数据分析", priority="high")
     print(f"结果: {result}")
-    
+
     # 5. 健康检查示例（多次执行以演示失败通知）
     print("\n=== 健康检查（只在失败时通知）===")
     services = ["数据库", "Redis", "API网关", "消息队列", "文件存储"]
@@ -168,19 +171,19 @@ def main():
             print(f"✅ {result}")
         except Exception as e:
             print(f"❌ {service} 检查失败: {e}")
-    
+
     # 6. 覆盖默认实例演示
     demo_override_instance()
-    
+
     print("\n=== 清除默认实例演示 ===")
     clear_default_notify_instance()
     print(f"清除后的默认实例: {get_default_notify_instance()}")
-    
+
     # 7. 清除后使用装饰器（会创建空实例并警告）
     @notify(title="清除后的任务")
     def task_after_clear():
         return "任务完成"
-    
+
     print("\n执行清除默认实例后的任务...")
     result = task_after_clear()
     print(f"结果: {result}")
@@ -189,10 +192,10 @@ def main():
 async def async_main():
     """异步示例"""
     print("\n=== 异步任务（使用默认实例）===")
-    
+
     # 重新设置默认实例（因为之前被清除了）
     setup_default_notify_instance()
-    
+
     print("执行异步下载任务...")
     result = await async_download("https://example.com/file.zip")
     print(f"结果: {result}")
@@ -201,10 +204,10 @@ async def async_main():
 if __name__ == "__main__":
     # 执行同步示例
     main()
-    
+
     # 执行异步示例
     asyncio.run(async_main())
-    
+
     print("\n" + "=" * 60)
     print("🎉 演示完成！")
     print("\n💡 使用提示:")

--- a/example/decorator_demo.py
+++ b/example/decorator_demo.py
@@ -17,7 +17,7 @@ import sys
 import time
 
 # 添加项目根目录到Python路径
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from use_notify import notify, useNotify
 from use_notify.channels.base import BaseChannel
@@ -26,15 +26,15 @@ from use_notify.channels.base import BaseChannel
 # 创建一个模拟通知渠道用于演示
 class ConsoleChannel(BaseChannel):
     """控制台输出通知渠道（用于演示）"""
-    
+
     def __init__(self, config=None):
         super().__init__(config or {})
-    
+
     def send(self, content, title=None):
         print(f"\n📢 [同步通知] {title}")
         print(f"📝 {content}")
         print("-" * 50)
-    
+
     async def send_async(self, content, title=None):
         print(f"\n📢 [异步通知] {title}")
         print(f"📝 {content}")
@@ -44,17 +44,17 @@ class ConsoleChannel(BaseChannel):
 def demo_basic_usage():
     """演示基础使用"""
     print("\n=== 基础使用演示 ===")
-    
+
     # 创建通知实例
     notify_instance = useNotify([ConsoleChannel()])
-    
+
     # 基础装饰器使用
     @notify(notify_instance=notify_instance)
     def simple_task():
         """简单任务"""
         time.sleep(1)  # 模拟任务执行
         return "任务完成"
-    
+
     print("执行简单任务...")
     result = simple_task()
     print(f"任务结果: {result}")
@@ -63,9 +63,9 @@ def demo_basic_usage():
 def demo_custom_configuration():
     """演示自定义配置"""
     print("\n=== 自定义配置演示 ===")
-    
+
     notify_instance = useNotify([ConsoleChannel()])
-    
+
     # 自定义标题和模板
     @notify(
         notify_instance=notify_instance,
@@ -73,14 +73,14 @@ def demo_custom_configuration():
         success_template="✅ {function_name} 成功处理了 {args[0]} 条记录，耗时 {execution_time:.2f}秒",
         error_template="❌ {function_name} 处理失败: {error_message}，已处理时间 {execution_time:.2f}秒",
         include_args=True,
-        include_result=True
+        include_result=True,
     )
     def process_data(record_count):
         """数据处理任务"""
         print(f"正在处理 {record_count} 条记录...")
         time.sleep(1.5)  # 模拟处理时间
         return f"成功处理了 {record_count} 条记录"
-    
+
     print("执行数据处理任务...")
     result = process_data(1000)
     print(f"处理结果: {result}")
@@ -89,21 +89,21 @@ def demo_custom_configuration():
 async def demo_async_functions():
     """演示异步函数支持"""
     print("\n=== 异步函数演示 ===")
-    
+
     notify_instance = useNotify([ConsoleChannel()])
-    
+
     @notify(
         notify_instance=notify_instance,
         title="异步下载任务",
         success_template="📥 {function_name} 下载完成，文件大小: {result}，耗时 {execution_time:.2f}秒",
-        include_result=True
+        include_result=True,
     )
     async def download_file(url):
         """异步下载文件"""
         print(f"开始下载: {url}")
         await asyncio.sleep(2)  # 模拟下载时间
         return "1.5MB"
-    
+
     print("执行异步下载任务...")
     result = await download_file("https://example.com/file.zip")
     print(f"下载结果: {result}")
@@ -112,13 +112,13 @@ async def demo_async_functions():
 def demo_error_handling():
     """演示错误处理"""
     print("\n=== 错误处理演示 ===")
-    
+
     notify_instance = useNotify([ConsoleChannel()])
-    
+
     @notify(
         notify_instance=notify_instance,
         title="可能失败的任务",
-        error_template="💥 {function_name} 执行失败\n🕐 执行时间: {execution_time:.2f}秒\n❗ 错误详情: {error_message}"
+        error_template="💥 {function_name} 执行失败\n🕐 执行时间: {execution_time:.2f}秒\n❗ 错误详情: {error_message}",
     )
     def risky_task(should_fail=False):
         """可能失败的任务"""
@@ -126,7 +126,7 @@ def demo_error_handling():
         if should_fail:
             raise ValueError("模拟的业务逻辑错误")
         return "任务成功完成"
-    
+
     # 成功情况
     print("执行成功的任务...")
     try:
@@ -134,7 +134,7 @@ def demo_error_handling():
         print(f"任务结果: {result}")
     except Exception as e:
         print(f"任务异常: {e}")
-    
+
     # 失败情况
     print("\n执行失败的任务...")
     try:
@@ -147,16 +147,16 @@ def demo_error_handling():
 def demo_advanced_options():
     """演示高级配置选项"""
     print("\n=== 高级配置选项演示 ===")
-    
+
     notify_instance = useNotify([ConsoleChannel()])
-    
+
     # 只在失败时通知
     @notify(
         notify_instance=notify_instance,
         title="监控任务",
         notify_on_success=False,  # 不发送成功通知
-        notify_on_error=True,     # 只发送失败通知
-        timeout=5.0               # 5秒超时
+        notify_on_error=True,  # 只发送失败通知
+        timeout=5.0,  # 5秒超时
     )
     def monitoring_task(check_status):
         """监控任务（只在失败时通知）"""
@@ -164,7 +164,7 @@ def demo_advanced_options():
         if check_status == "error":
             raise RuntimeError("系统检测到异常状态")
         return "系统状态正常"
-    
+
     # 成功情况（不会发送通知）
     print("执行正常监控检查...")
     try:
@@ -173,7 +173,7 @@ def demo_advanced_options():
         print("（注意：成功时不发送通知）")
     except Exception as e:
         print(f"监控异常: {e}")
-    
+
     # 失败情况（会发送通知）
     print("\n执行异常监控检查...")
     try:
@@ -186,14 +186,14 @@ def demo_advanced_options():
 def demo_without_notify_instance():
     """演示不提供通知实例的情况"""
     print("\n=== 无通知实例演示 ===")
-    
+
     # 不提供 notify_instance（会创建空实例，不会实际发送通知）
     @notify(title="测试任务")
     def test_task():
         """测试任务"""
         time.sleep(0.5)
         return "测试完成"
-    
+
     print("执行测试任务（无通知渠道）...")
     result = test_task()
     print(f"任务结果: {result}")
@@ -203,9 +203,9 @@ def demo_without_notify_instance():
 def demo_complex_scenario():
     """演示复杂使用场景"""
     print("\n=== 复杂场景演示 ===")
-    
+
     notify_instance = useNotify([ConsoleChannel()])
-    
+
     @notify(
         notify_instance=notify_instance,
         title="批量处理任务",
@@ -226,33 +226,24 @@ def demo_complex_scenario():
             "  - 错误信息: {error_message}"
         ),
         include_args=True,
-        include_result=True
+        include_result=True,
     )
     def batch_process(input_file, output_file, mode="standard", validate=True):
         """批量处理任务"""
         print(f"开始批量处理: {input_file} -> {output_file}")
         print(f"处理模式: {mode}, 验证: {validate}")
-        
+
         # 模拟处理过程
         time.sleep(2)
-        
+
         if mode == "error":
             raise ValueError("处理模式配置错误")
-        
-        return {
-            "processed_records": 5000,
-            "success_rate": "99.8%",
-            "output_size": "2.3MB"
-        }
-    
+
+        return {"processed_records": 5000, "success_rate": "99.8%", "output_size": "2.3MB"}
+
     print("执行复杂批量处理任务...")
     try:
-        result = batch_process(
-            "data/input.csv",
-            "data/output.csv",
-            mode="advanced",
-            validate=True
-        )
+        result = batch_process("data/input.csv", "data/output.csv", mode="advanced", validate=True)
         print(f"处理结果: {result}")
     except Exception as e:
         print(f"处理异常: {e}")
@@ -262,7 +253,7 @@ async def main():
     """主函数"""
     print("🚀 @notify 装饰器功能演示")
     print("=" * 60)
-    
+
     # 同步演示
     demo_basic_usage()
     demo_custom_configuration()
@@ -270,10 +261,10 @@ async def main():
     demo_advanced_options()
     demo_without_notify_instance()
     demo_complex_scenario()
-    
+
     # 异步演示
     await demo_async_functions()
-    
+
     print("\n" + "=" * 60)
     print("🎉 演示完成！")
     print("\n💡 使用提示:")

--- a/example/decorator_real_usage.py
+++ b/example/decorator_real_usage.py
@@ -8,15 +8,15 @@
 """
 
 import asyncio
-import sys
 import os
+import sys
 import time
 from datetime import datetime
 
 # 添加项目根目录到Python路径
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from use_notify import useNotify, useNotifyChannel, notify
+from use_notify import notify, useNotify, useNotifyChannel
 
 
 def create_notify_instance():
@@ -27,18 +27,18 @@ def create_notify_instance():
         # "DING": {"token": "your_ding_token_here"},
         # "WECHAT": {"token": "your_wechat_webhook_token_here"},
     }
-    
+
     # 如果有配置，使用 from_settings 创建
     if settings:
         return useNotify.from_settings(settings)
-    
+
     # 方式2: 手动添加通道
     notify_instance = useNotify()
     # notify_instance.add(
     #     useNotifyChannel.Bark({"token": "your_bark_token_here"}),
     #     useNotifyChannel.Ding({"token": "your_ding_token_here"})
     # )
-    
+
     return notify_instance
 
 
@@ -52,21 +52,21 @@ notify_instance = create_notify_instance()
     title="数据处理任务",
     success_template="✅ {function_name} 处理完成\n📊 处理了 {args[0]} 条记录\n⏱️ 耗时: {execution_time:.2f}秒",
     error_template="❌ {function_name} 处理失败\n📊 目标记录: {args[0]} 条\n⏱️ 耗时: {execution_time:.2f}秒\n🚨 错误: {error_message}",
-    include_args=True
+    include_args=True,
 )
 def process_user_data(record_count):
     """处理用户数据"""
     print(f"开始处理 {record_count} 条用户数据...")
-    
+
     # 模拟数据处理
     for i in range(record_count // 100):
         time.sleep(0.1)  # 模拟处理时间
         print(f"已处理 {(i + 1) * 100} 条记录")
-    
+
     # 模拟可能的错误
     if record_count > 10000:
         raise ValueError("记录数量超过系统限制")
-    
+
     return f"成功处理 {record_count} 条用户数据"
 
 
@@ -76,19 +76,19 @@ def process_user_data(record_count):
     title="文件备份",
     success_template="💾 备份完成\n📁 源路径: {args[0]}\n📁 目标路径: {args[1]}\n⏱️ 耗时: {execution_time:.2f}秒\n📋 结果: {result}",
     include_args=True,
-    include_result=True
+    include_result=True,
 )
 def backup_files(source_path, target_path):
     """备份文件"""
     print(f"开始备份: {source_path} -> {target_path}")
-    
+
     # 模拟备份过程
     time.sleep(2)
-    
+
     return {
         "files_copied": 150,
         "total_size": "2.3GB",
-        "backup_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        "backup_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     }
 
 
@@ -99,19 +99,19 @@ def backup_files(source_path, target_path):
     success_template="🔄 API同步完成\n🌐 接口: {kwargs[api_endpoint]}\n📊 同步数据: {result[records_synced]} 条\n⏱️ 耗时: {execution_time:.2f}秒",
     error_template="🔄 API同步失败\n🌐 接口: {kwargs[api_endpoint]}\n⏱️ 耗时: {execution_time:.2f}秒\n🚨 错误: {error_message}",
     include_args=True,
-    include_result=True
+    include_result=True,
 )
 async def sync_api_data(api_endpoint, batch_size=100):
     """异步同步API数据"""
     print(f"开始同步API数据: {api_endpoint}")
-    
+
     # 模拟API调用
     await asyncio.sleep(3)
-    
+
     return {
         "records_synced": 500,
         "last_sync_time": datetime.now().isoformat(),
-        "status": "success"
+        "status": "success",
     }
 
 
@@ -120,21 +120,22 @@ async def sync_api_data(api_endpoint, batch_size=100):
     notify_instance=notify_instance,
     title="系统监控",
     notify_on_success=False,  # 不发送成功通知
-    notify_on_error=True,     # 只发送失败通知
-    error_template="🚨 系统监控告警\n🖥️ 检查项: {args[0]}\n⏱️ 检查时间: {execution_time:.2f}秒\n❗ 错误详情: {error_message}"
+    notify_on_error=True,  # 只发送失败通知
+    error_template="🚨 系统监控告警\n🖥️ 检查项: {args[0]}\n⏱️ 检查时间: {execution_time:.2f}秒\n❗ 错误详情: {error_message}",
 )
 def health_check(check_name):
     """系统健康检查"""
     print(f"执行健康检查: {check_name}")
-    
+
     # 模拟检查过程
     time.sleep(0.5)
-    
+
     # 模拟检查结果
     import random
+
     if random.random() < 0.1:  # 10% 概率失败
         raise RuntimeError(f"{check_name} 检查失败: 响应超时")
-    
+
     return f"{check_name} 检查通过"
 
 
@@ -151,40 +152,37 @@ def health_check(check_name):
         "⏱️ 总耗时: {execution_time:.2f}秒"
     ),
     include_args=True,
-    include_result=True
+    include_result=True,
 )
 def batch_process_tasks(task_count, task_type="default", parallel=False):
     """批量处理任务"""
     print(f"开始批量处理 {task_count} 个 {task_type} 任务")
-    
+
     success_count = 0
     failed_count = 0
-    
+
     for i in range(task_count):
         time.sleep(0.1)  # 模拟任务处理
-        
+
         # 模拟成功/失败
         import random
+
         if random.random() < 0.9:  # 90% 成功率
             success_count += 1
         else:
             failed_count += 1
-        
+
         if (i + 1) % 10 == 0:
             print(f"已处理 {i + 1}/{task_count} 个任务")
-    
-    return {
-        "success_count": success_count,
-        "failed_count": failed_count,
-        "total_count": task_count
-    }
+
+    return {"success_count": success_count, "failed_count": failed_count, "total_count": task_count}
 
 
 def main():
     """主函数 - 同步示例"""
     print("🚀 @notify 装饰器真实使用示例")
     print("=" * 50)
-    
+
     # 示例1: 数据处理
     print("\n1. 执行数据处理任务...")
     try:
@@ -192,7 +190,7 @@ def main():
         print(f"✅ {result}")
     except Exception as e:
         print(f"❌ 处理失败: {e}")
-    
+
     # 示例2: 文件备份
     print("\n2. 执行文件备份任务...")
     try:
@@ -200,7 +198,7 @@ def main():
         print(f"✅ 备份完成: {result}")
     except Exception as e:
         print(f"❌ 备份失败: {e}")
-    
+
     # 示例3: 健康检查（多次执行以演示失败通知）
     print("\n3. 执行系统健康检查...")
     for check in ["数据库连接", "Redis连接", "API服务", "磁盘空间", "内存使用"]:
@@ -209,7 +207,7 @@ def main():
             print(f"✅ {result}")
         except Exception as e:
             print(f"❌ {check} 失败: {e}")
-    
+
     # 示例4: 批量任务
     print("\n4. 执行批量任务处理...")
     try:
@@ -223,10 +221,7 @@ async def async_main():
     """异步主函数"""
     print("\n5. 执行异步API同步...")
     try:
-        result = await sync_api_data(
-            api_endpoint="https://api.example.com/users",
-            batch_size=200
-        )
+        result = await sync_api_data(api_endpoint="https://api.example.com/users", batch_size=200)
         print(f"✅ API同步完成: {result}")
     except Exception as e:
         print(f"❌ API同步失败: {e}")
@@ -235,10 +230,10 @@ async def async_main():
 if __name__ == "__main__":
     # 执行同步示例
     main()
-    
+
     # 执行异步示例
     asyncio.run(async_main())
-    
+
     print("\n" + "=" * 50)
     print("🎉 示例执行完成！")
     print("\n💡 配置提示:")

--- a/example/ntfy_demo.py
+++ b/example/ntfy_demo.py
@@ -8,6 +8,7 @@ Ntfy.sh 通知渠道使用示例
 3. 同步和异步发送
 4. 与其他渠道的组合使用
 """
+
 import asyncio
 
 from use_notify import useNotify

--- a/example/ntfy_demo.py
+++ b/example/ntfy_demo.py
@@ -17,19 +17,17 @@ from use_notify.channels import Ntfy
 def basic_usage_example():
     """基础使用示例"""
     print("=== 基础使用示例 ===")
-    
+
     # 最简配置，只需要指定主题
-    ntfy = Ntfy({
-        "topic": "my-notifications"
-    })
-    
+    ntfy = Ntfy({"topic": "my-notifications"})
+
     # 发送简单消息
     try:
         ntfy.send("这是一条测试消息")
         print("✓ 基础消息发送成功")
     except Exception as e:
         print(f"✗ 发送失败: {e}")
-    
+
     # 发送带标题的消息
     try:
         ntfy.send("这是消息内容", "消息标题")
@@ -41,16 +39,18 @@ def basic_usage_example():
 def advanced_features_example():
     """高级功能使用示例"""
     print("\n=== 高级功能使用示例 ===")
-    
+
     # 配置高级功能
-    ntfy = Ntfy({
-        "topic": "my-notifications",
-        "priority": 4,  # 高优先级 (1-5)
-        "tags": ["warning", "computer"],  # 标签
-        "click": "https://example.com",  # 点击跳转链接
-        "attach": "https://example.com/image.jpg"  # 附件
-    })
-    
+    ntfy = Ntfy(
+        {
+            "topic": "my-notifications",
+            "priority": 4,  # 高优先级 (1-5)
+            "tags": ["warning", "computer"],  # 标签
+            "click": "https://example.com",  # 点击跳转链接
+            "attach": "https://example.com/image.jpg",  # 附件
+        }
+    )
+
     try:
         ntfy.send("这是一条高优先级警告消息", "系统警告")
         print("✓ 高级功能消息发送成功")
@@ -61,13 +61,12 @@ def advanced_features_example():
 def custom_server_example():
     """自定义服务器示例"""
     print("\n=== 自定义服务器示例 ===")
-    
+
     # 使用自托管的 ntfy.sh 服务器
-    ntfy = Ntfy({
-        "topic": "my-notifications",
-        "base_url": "https://ntfy.example.com"  # 自定义服务器
-    })
-    
+    ntfy = Ntfy(
+        {"topic": "my-notifications", "base_url": "https://ntfy.example.com"}  # 自定义服务器
+    )
+
     try:
         ntfy.send("来自自定义服务器的消息", "自定义服务器")
         print("✓ 自定义服务器消息发送成功")
@@ -78,12 +77,9 @@ def custom_server_example():
 async def async_usage_example():
     """异步使用示例"""
     print("\n=== 异步使用示例 ===")
-    
-    ntfy = Ntfy({
-        "topic": "my-notifications",
-        "priority": 3
-    })
-    
+
+    ntfy = Ntfy({"topic": "my-notifications", "priority": 3})
+
     try:
         await ntfy.send_async("这是异步发送的消息", "异步消息")
         print("✓ 异步消息发送成功")
@@ -94,19 +90,13 @@ async def async_usage_example():
 def publisher_integration_example():
     """与 Publisher 集成使用示例"""
     print("\n=== Publisher 集成示例 ===")
-    
+
     # 创建通知发布器
     notify = useNotify()
-    
+
     # 添加 ntfy 渠道
-    notify.add(
-        Ntfy({
-            "topic": "my-notifications",
-            "priority": 3,
-            "tags": ["app", "notification"]
-        })
-    )
-    
+    notify.add(Ntfy({"topic": "my-notifications", "priority": 3, "tags": ["app", "notification"]}))
+
     try:
         notify.publish("通过 Publisher 发送的消息", "Publisher 消息")
         print("✓ Publisher 集成消息发送成功")
@@ -117,15 +107,10 @@ def publisher_integration_example():
 async def async_publisher_example():
     """异步 Publisher 示例"""
     print("\n=== 异步 Publisher 示例 ===")
-    
+
     notify = useNotify()
-    notify.add(
-        Ntfy({
-            "topic": "my-notifications",
-            "priority": 2
-        })
-    )
-    
+    notify.add(Ntfy({"topic": "my-notifications", "priority": 2}))
+
     try:
         await notify.publish_async("异步 Publisher 消息", "异步 Publisher")
         print("✓ 异步 Publisher 消息发送成功")
@@ -136,20 +121,20 @@ async def async_publisher_example():
 def from_settings_example():
     """从配置创建示例"""
     print("\n=== 从配置创建示例 ===")
-    
+
     # 配置字典
     settings = {
         "NTFY": {
             "topic": "my-notifications",
             "priority": 3,
             "tags": ["config", "demo"],
-            "click": "https://github.com/ntfy-sh/ntfy"
+            "click": "https://github.com/ntfy-sh/ntfy",
         }
     }
-    
+
     # 从配置创建通知器
     notify = useNotify.from_settings(settings)
-    
+
     try:
         notify.publish("从配置创建的消息", "配置消息")
         print("✓ 从配置创建消息发送成功")
@@ -160,25 +145,23 @@ def from_settings_example():
 def actions_example():
     """交互操作示例"""
     print("\n=== 交互操作示例 ===")
-    
+
     # 配置交互操作
-    ntfy = Ntfy({
-        "topic": "my-notifications",
-        "actions": [
-            {
-                "action": "view",
-                "label": "打开网站",
-                "url": "https://ntfy.sh"
-            },
-            {
-                "action": "http",
-                "label": "重启服务",
-                "url": "https://api.example.com/restart",
-                "method": "POST"
-            }
-        ]
-    })
-    
+    ntfy = Ntfy(
+        {
+            "topic": "my-notifications",
+            "actions": [
+                {"action": "view", "label": "打开网站", "url": "https://ntfy.sh"},
+                {
+                    "action": "http",
+                    "label": "重启服务",
+                    "url": "https://api.example.com/restart",
+                    "method": "POST",
+                },
+            ],
+        }
+    )
+
     try:
         ntfy.send("服务器需要重启，请选择操作", "服务器警告")
         print("✓ 交互操作消息发送成功")
@@ -190,7 +173,7 @@ async def main():
     """主函数，运行所有示例"""
     print("Ntfy.sh 通知渠道使用示例")
     print("=" * 50)
-    
+
     # 同步示例
     basic_usage_example()
     advanced_features_example()
@@ -198,11 +181,11 @@ async def main():
     publisher_integration_example()
     from_settings_example()
     actions_example()
-    
+
     # 异步示例
     await async_usage_example()
     await async_publisher_example()
-    
+
     print("\n" + "=" * 50)
     print("所有示例运行完成！")
     print("\n注意：")

--- a/example/ntfy_from_settings.py
+++ b/example/ntfy_from_settings.py
@@ -5,11 +5,7 @@
 from use_notify import useNotify
 
 # 基础配置
-settings = {
-    "NTFY": {
-        "topic": "my-notifications"
-    }
-}
+settings = {"NTFY": {"topic": "my-notifications"}}
 
 # 从配置创建通知器
 notify = useNotify.from_settings(settings)
@@ -27,16 +23,12 @@ advanced_settings = {
     "NTFY": {
         "topic": "my-notifications",
         "base_url": "https://ntfy.sh",  # 可选：自定义服务器
-        "priority": 3,                   # 可选：优先级 (1-5)
-        "tags": ["python", "demo"],     # 可选：标签
+        "priority": 3,  # 可选：优先级 (1-5)
+        "tags": ["python", "demo"],  # 可选：标签
         "click": "https://github.com/ntfy-sh/ntfy",  # 可选：点击链接
-        "actions": [                     # 可选：交互操作
-            {
-                "action": "view",
-                "label": "查看详情",
-                "url": "https://example.com"
-            }
-        ]
+        "actions": [  # 可选：交互操作
+            {"action": "view", "label": "查看详情", "url": "https://example.com"}
+        ],
     }
 }
 

--- a/example/ntfy_from_settings.py
+++ b/example/ntfy_from_settings.py
@@ -2,6 +2,7 @@
 """
 使用配置字典创建 Ntfy 通知渠道的简单示例
 """
+
 from use_notify import useNotify
 
 # 基础配置

--- a/example/ntfy_integration.py
+++ b/example/ntfy_integration.py
@@ -2,6 +2,7 @@
 """
 Ntfy.sh 与 useNotify 集成使用示例
 """
+
 import asyncio
 
 from use_notify import useNotify

--- a/example/ntfy_integration.py
+++ b/example/ntfy_integration.py
@@ -3,18 +3,13 @@
 Ntfy.sh 与 useNotify 集成使用示例
 """
 import asyncio
+
 from use_notify import useNotify
 from use_notify.channels import Ntfy
 
 # 方式1: 直接添加 Ntfy 渠道
 notify = useNotify()
-notify.add(
-    Ntfy({
-        "topic": "my-notifications",
-        "priority": 3,
-        "tags": ["app", "notification"]
-    })
-)
+notify.add(Ntfy({"topic": "my-notifications", "priority": 3, "tags": ["app", "notification"]}))
 
 # 同步发送
 try:
@@ -22,6 +17,7 @@ try:
     print("✓ 集成同步发送成功")
 except Exception as e:
     print(f"✗ 集成同步发送失败: {e}")
+
 
 # 异步发送
 async def async_integration():
@@ -31,6 +27,7 @@ async def async_integration():
     except Exception as e:
         print(f"✗ 集成异步发送失败: {e}")
 
+
 asyncio.run(async_integration())
 
 # 方式2: 从配置创建
@@ -39,7 +36,7 @@ settings = {
         "topic": "my-notifications",
         "priority": 4,
         "tags": ["config", "demo"],
-        "click": "https://ntfy.sh"
+        "click": "https://ntfy.sh",
     }
 }
 

--- a/example/ntfy_simple.py
+++ b/example/ntfy_simple.py
@@ -4,6 +4,7 @@ Ntfy.sh 通知渠道简单使用示例
 """
 
 import asyncio
+
 from use_notify.channels import Ntfy
 
 # 基础使用

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ wheel-exclude = ["/SKILL.md", "/skill-references/**"]
 
 [tool.black]
 line-length = 100
+target-version = ["py38"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,10 @@ build-backend = "uv_build"
 [tool.uv.build-backend]
 source-exclude = ["/SKILL.md", "/skill-references/**"]
 wheel-exclude = ["/SKILL.md", "/skill-references/**"]
+
+[tool.black]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100

--- a/src/use_notify/__init__.py
+++ b/src/use_notify/__init__.py
@@ -1,12 +1,18 @@
 # flake8: noqa: F401
 from . import channels as useNotifyChannel
+from .decorator import (
+    clear_default_notify_instance,
+    get_default_notify_instance,
+    notify,
+    set_default_notify_instance,
+)
 from .notification import (
-    Notify as useNotify,
     NotificationPublishError,
+)
+from .notification import Notify as useNotify
+from .notification import (
     RetryConfig,
 )
-from .decorator import notify, set_default_notify_instance, get_default_notify_instance, clear_default_notify_instance
-
 
 __all__ = [
     "useNotifyChannel",

--- a/src/use_notify/__init__.py
+++ b/src/use_notify/__init__.py
@@ -6,13 +6,9 @@ from .decorator import (
     notify,
     set_default_notify_instance,
 )
-from .notification import (
-    NotificationPublishError,
-)
+from .notification import NotificationPublishError
 from .notification import Notify as useNotify
-from .notification import (
-    RetryConfig,
-)
+from .notification import RetryConfig
 
 __all__ = [
     "useNotifyChannel",

--- a/src/use_notify/channels/__init__.py
+++ b/src/use_notify/channels/__init__.py
@@ -1,15 +1,15 @@
 # flake8: noqa: F401
-from .console import Console
 from .bark import Bark
 from .base import BaseChannel
 from .chanify import Chanify
+from .console import Console
 from .ding import Ding
 from .email import Email
+from .feishu import Feishu
 from .ntfy import Ntfy
 from .pushdeer import PushDeer
 from .pushover import PushOver
 from .wechat import WeChat
-from .feishu import Feishu
 
 # 兼容wecom
 WeCom = WeChat

--- a/src/use_notify/channels/bark.py
+++ b/src/use_notify/channels/bark.py
@@ -18,7 +18,7 @@ class Bark(BaseChannel):
             base_url = self.config.base_url.rstrip("/")
         else:
             base_url = "https://api.day.app"
-        
+
         return f"{base_url}/{self.config.token}"
 
     @property
@@ -29,15 +29,15 @@ class Bark(BaseChannel):
         payload = {
             "body": content,
         }
-        
+
         if title:
             payload["title"] = title
-            
+
         # Optional parameters from config
         for param in ["badge", "sound", "icon", "group", "url"]:
             if hasattr(self.config, param) and getattr(self.config, param) is not None:
                 payload[param] = getattr(self.config, param)
-                
+
         return payload
 
     def send(self, content, title=None):

--- a/src/use_notify/channels/chanify.py
+++ b/src/use_notify/channels/chanify.py
@@ -18,7 +18,7 @@ class Chanify(BaseChannel):
             base_url = self.config.base_url.rstrip("/")
         else:
             base_url = "https://api.chanify.net"
-        
+
         return f"{base_url}/v1/sender/{self.config.token}"
 
     @property

--- a/src/use_notify/channels/console.py
+++ b/src/use_notify/channels/console.py
@@ -1,18 +1,19 @@
 from .base import BaseChannel
 
+
 class Console(BaseChannel):
     """控制台通知渠道（用于演示）"""
-    
+
     def __init__(self, config=None):
         super().__init__(config or {})
-    
+
     def send(self, content, title=None):
         """发送通知到控制台"""
         title_display = title or "消息提醒"
         print(f"\n📢 [默认实例通知] {title_display}")
         print(f"📝 {content}")
         print("-" * 50)
-    
+
     async def send_async(self, content, title=None):
         """异步发送通知到控制台"""
         title_display = title or "消息提醒"

--- a/src/use_notify/channels/email.py
+++ b/src/use_notify/channels/email.py
@@ -23,20 +23,20 @@ class Email(BaseChannel):
 
     def _validate_required_fields(self):
         """校验必填字段"""
-        required_fields = ['server', 'username', 'password', 'from_email']
+        required_fields = ["server", "username", "password", "from_email"]
         missing_fields = []
-        
+
         for field in required_fields:
             if not hasattr(self.config, field) or not getattr(self.config, field):
                 missing_fields.append(field)
-        
+
         # 单独校验端口号
         if not self.config.port and not isinstance(self.config.port, int):
-            missing_fields.append('port')
-        
+            missing_fields.append("port")
+
         if missing_fields:
             raise ValueError(f"缺少必填字段: {', '.join(missing_fields)}")
-        
+
         # 校验端口号是否为有效整数
         try:
             port = int(self.config.port)

--- a/src/use_notify/channels/feishu.py
+++ b/src/use_notify/channels/feishu.py
@@ -23,28 +23,18 @@ class Feishu(BaseChannel):
 
     def build_api_body(self, content, title=None):
         title = title or "消息提醒"
-        api_body_content = [{
-            "tag": "text",
-            "text": content
-        }]
+        api_body_content = [{"tag": "text", "text": content}]
 
         if self.config.at_all:
             api_body_content.append({"tag": "at", "user_id": "all"})
         if self.config.at_user_ids:
-            api_body_content.extend([{"tag": "at", "user_id": user_id_} for user_id_ in self.config.at_user_ids])
+            api_body_content.extend(
+                [{"tag": "at", "user_id": user_id_} for user_id_ in self.config.at_user_ids]
+            )
 
         return {
             "msg_type": "post",
-            "content": {
-                "post": {
-                    "zh_cn": {
-                        "title": title,
-                        "content": [
-                            api_body_content
-                        ]
-                    }
-                }
-            }
+            "content": {"post": {"zh_cn": {"title": title, "content": [api_body_content]}}},
         }
 
     def send(self, content, title=None):

--- a/src/use_notify/channels/ntfy.py
+++ b/src/use_notify/channels/ntfy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -15,25 +15,25 @@ class Ntfy(BaseChannel):
     def __init__(self, config: dict):
         """
         初始化 Ntfy 渠道
-        
+
         Args:
             config: 配置字典，必须包含 'topic'，可选包含 'base_url' 等参数
         """
         super().__init__(config)
-        
+
         # 验证必需的配置参数
-        if not hasattr(self.config, 'topic') or not self.config.topic:
+        if not hasattr(self.config, "topic") or not self.config.topic:
             raise ValueError("Ntfy channel requires 'topic' in config")
 
     @property
     def api_url(self):
         """构建 ntfy.sh API URL"""
         # 检查是否有自定义 base_url，否则使用默认值
-        if hasattr(self.config, 'base_url') and self.config.base_url:
+        if hasattr(self.config, "base_url") and self.config.base_url:
             base_url = self.config.base_url.rstrip("/")
         else:
             base_url = "https://ntfy.sh"
-        
+
         return f"{base_url}/{self.config.topic}"
 
     @property
@@ -44,72 +44,72 @@ class Ntfy(BaseChannel):
     def _prepare_payload(self, content: str, title: Optional[str] = None) -> Dict[str, Any]:
         """
         准备请求负载
-        
+
         Args:
             content: 消息内容
             title: 消息标题（可选）
-            
+
         Returns:
             dict: 请求负载
         """
         payload = {
             "message": content,
         }
-        
+
         if title:
             payload["title"] = title
-        
+
         # 添加高级功能支持
         # 优先级支持 (1-5)
-        if hasattr(self.config, 'priority') and self.config.priority is not None:
+        if hasattr(self.config, "priority") and self.config.priority is not None:
             payload["priority"] = self.config.priority
-        
+
         # 标签支持
-        if hasattr(self.config, 'tags') and self.config.tags:
+        if hasattr(self.config, "tags") and self.config.tags:
             payload["tags"] = self.config.tags
-        
+
         # 点击 URL 支持
-        if hasattr(self.config, 'click') and self.config.click:
+        if hasattr(self.config, "click") and self.config.click:
             payload["click"] = self.config.click
-        
+
         # 附件 URL 支持
-        if hasattr(self.config, 'attach') and self.config.attach:
+        if hasattr(self.config, "attach") and self.config.attach:
             payload["attach"] = self.config.attach
-        
+
         # 操作支持
-        if hasattr(self.config, 'actions') and self.config.actions:
+        if hasattr(self.config, "actions") and self.config.actions:
             payload["actions"] = self.config.actions
-            
+
         return payload
 
     def send(self, content: str, title: Optional[str] = None) -> None:
         """
         发送通知到 ntfy.sh
-        
+
         Args:
             content: 消息内容
             title: 消息标题（可选）
         """
         payload = self._prepare_payload(content, title)
-        
+
         with httpx.Client() as client:
             response = client.post(self.api_url, headers=self.headers, json=payload)
             response.raise_for_status()
-        
+
         logger.debug("`ntfy` send successfully")
 
     async def send_async(self, content: str, title: Optional[str] = None) -> None:
         """
         异步发送通知到 ntfy.sh
-        
+
         Args:
             content: 消息内容
             title: 消息标题（可选）
         """
         payload = self._prepare_payload(content, title)
-        
+
         async with httpx.AsyncClient() as client:
             response = await client.post(self.api_url, headers=self.headers, json=payload)
             response.raise_for_status()
-        
+
         logger.debug("`ntfy` send successfully")

--- a/src/use_notify/channels/pushdeer.py
+++ b/src/use_notify/channels/pushdeer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-from urllib.parse import quote
 
 import httpx
 
@@ -103,8 +102,6 @@ class PushDeer(BaseChannel):
         params = self._prepare_params(content, title)
 
         async with httpx.AsyncClient() as client:
-            response = await client.get(
-                self.api_url, params=params, headers=self.headers
-            )
+            response = await client.get(self.api_url, params=params, headers=self.headers)
             response.raise_for_status()
         logger.debug("`pushdeer` send message successfully")

--- a/src/use_notify/channels/wechat.py
+++ b/src/use_notify/channels/wechat.py
@@ -13,9 +13,7 @@ class WeChat(BaseChannel):
 
     @property
     def api_url(self):
-        return (
-            f"https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={self.config.token}"
-        )
+        return f"https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={self.config.token}"
 
     @property
     def headers(self):
@@ -29,7 +27,7 @@ class WeChat(BaseChannel):
             api_body["markdown"]["mentioned_list"] = self.config.mentioned_list
         if self.config.mentioned_mobile_list:
             api_body["markdown"]["mentioned_mobile_list"] = self.config.mentioned_mobile_list
-        
+
         return api_body
 
     def send(self, content, title=None):

--- a/src/use_notify/decorator/__init__.py
+++ b/src/use_notify/decorator/__init__.py
@@ -1,20 +1,16 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa: F401
-from .core import (
-    notify, 
-    NotifyDecorator, 
-    set_default_notify_instance, 
-    get_default_notify_instance, 
-    clear_default_notify_instance
-)
 from .context import ExecutionContext
+from .core import (
+    NotifyDecorator,
+    clear_default_notify_instance,
+    get_default_notify_instance,
+    notify,
+    set_default_notify_instance,
+)
+from .exceptions import NotifyConfigError, NotifyDecoratorError, NotifySendError
 from .formatter import MessageFormatter
 from .sender import NotificationSender
-from .exceptions import (
-    NotifyDecoratorError,
-    NotifyConfigError,
-    NotifySendError
-)
 
 __all__ = [
     "notify",

--- a/src/use_notify/decorator/context.py
+++ b/src/use_notify/decorator/context.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 @dataclass
 class ExecutionContext:
     """函数执行上下文信息"""
+
     function_name: str
     start_time: datetime
     end_time: Optional[datetime] = None
@@ -19,24 +20,24 @@ class ExecutionContext:
     result: Any = None
     exception: Optional[Exception] = None
     execution_time: Optional[float] = None
-    
+
     def mark_success(self, result: Any) -> None:
         """标记执行成功"""
         self.end_time = datetime.now()
         self.result = result
         self.execution_time = (self.end_time - self.start_time).total_seconds()
-    
+
     def mark_error(self, exception: Exception) -> None:
         """标记执行失败"""
         self.end_time = datetime.now()
         self.exception = exception
         self.execution_time = (self.end_time - self.start_time).total_seconds()
-    
+
     @property
     def is_success(self) -> bool:
         """是否执行成功"""
         return self.exception is None
-    
+
     @property
     def error_message(self) -> str:
         """错误信息"""

--- a/src/use_notify/decorator/core.py
+++ b/src/use_notify/decorator/core.py
@@ -3,12 +3,11 @@
 核心装饰器实现
 """
 
-import asyncio
-from contextvars import ContextVar
 import functools
 import inspect
 import logging
 import threading
+from contextvars import ContextVar
 from datetime import datetime
 from typing import Callable, Optional, Sequence, Type
 
@@ -17,7 +16,6 @@ from .context import ExecutionContext
 from .exceptions import NotifyConfigError
 from .formatter import MessageFormatter
 from .sender import NotificationSender
-
 
 logger = logging.getLogger(__name__)
 
@@ -34,16 +32,16 @@ _decorators_lock = threading.Lock()
 
 def set_default_notify_instance(notify_instance: Notify) -> None:
     """设置当前执行上下文的默认通知实例
-    
+
     Args:
         notify_instance: 要设置为默认的 Notify 实例
-    
+
     Example:
         # 设置默认通知实例
         default_notify = useNotify()
         default_notify.add(useNotifyChannel.Bark({"token": "your_token"}))
         set_default_notify_instance(default_notify)
-        
+
         # 现在可以直接使用装饰器，无需传递 notify_instance
         @notify()
         def my_task():
@@ -57,7 +55,7 @@ def set_default_notify_instance(notify_instance: Notify) -> None:
 
 def get_default_notify_instance() -> Optional[Notify]:
     """获取当前执行上下文的默认通知实例
-    
+
     Returns:
         当前的默认通知实例，如果未设置则返回 None
     """
@@ -94,9 +92,19 @@ class NotifyDecorator:
     ):
         # 验证配置
         self._validate_config(
-            notify_instance, title, success_template, error_template,
-            notify_on_success, notify_on_error, include_args, include_result, timeout,
-            max_retries, retry_delay, retry_backoff, retriable_exceptions,
+            notify_instance,
+            title,
+            success_template,
+            error_template,
+            notify_on_success,
+            notify_on_error,
+            include_args,
+            include_result,
+            timeout,
+            max_retries,
+            retry_delay,
+            retry_backoff,
+            retriable_exceptions,
         )
 
         self.notify_instance = notify_instance
@@ -110,106 +118,106 @@ class NotifyDecorator:
         self.retriable_exceptions = retriable_exceptions
         # 使用装饰器实例的唯一ID作为标识
         self._instance_id = id(self)
-        
+
         # 创建消息格式化器
         self.formatter = MessageFormatter(
             success_template=success_template,
             error_template=error_template,
             include_args=include_args,
-            include_result=include_result
+            include_result=include_result,
         )
-        
+
     def __call__(self, func: Callable) -> Callable:
         """装饰器调用"""
         if inspect.iscoroutinefunction(func):
             return self._wrap_async_function(func)
         else:
             return self._wrap_sync_function(func)
-    
+
     def _wrap_sync_function(self, func: Callable) -> Callable:
         """包装同步函数"""
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             # 创建执行上下文
             context = ExecutionContext(
-                function_name=func.__name__,
-                start_time=datetime.now(),
-                args=args,
-                kwargs=kwargs
+                function_name=func.__name__, start_time=datetime.now(), args=args, kwargs=kwargs
             )
-            
+
             logger.debug(f"开始执行函数: {func.__name__}")
-            
+
             try:
                 # 执行原函数
                 result = func(*args, **kwargs)
-                
+
                 # 标记成功
                 context.mark_success(result)
                 logger.debug(f"函数 {func.__name__} 执行成功，耗时 {context.execution_time:.2f}秒")
-                
+
                 # 发送成功通知
                 if self.notify_on_success:
                     self._send_success_notification(context)
-                
+
                 return result
-                
+
             except Exception as e:
                 # 标记失败
                 context.mark_error(e)
                 logger.debug(f"函数 {func.__name__} 执行失败，耗时 {context.execution_time:.2f}秒")
-                
+
                 # 发送失败通知
                 if self.notify_on_error:
                     self._send_error_notification(context)
-                
+
                 # 重新抛出异常
                 raise
-        
+
         return wrapper
-    
+
     def _wrap_async_function(self, func: Callable) -> Callable:
         """包装异步函数"""
+
         @functools.wraps(func)
         async def async_wrapper(*args, **kwargs):
             # 创建执行上下文
             context = ExecutionContext(
-                function_name=func.__name__,
-                start_time=datetime.now(),
-                args=args,
-                kwargs=kwargs
+                function_name=func.__name__, start_time=datetime.now(), args=args, kwargs=kwargs
             )
-            
+
             logger.debug(f"开始执行异步函数: {func.__name__}")
-            
+
             try:
                 # 执行原函数
                 result = await func(*args, **kwargs)
-                
+
                 # 标记成功
                 context.mark_success(result)
-                logger.debug(f"异步函数 {func.__name__} 执行成功，耗时 {context.execution_time:.2f}秒")
-                
+                logger.debug(
+                    f"异步函数 {func.__name__} 执行成功，耗时 {context.execution_time:.2f}秒"
+                )
+
                 # 发送成功通知
                 if self.notify_on_success:
                     await self._send_success_notification_async(context)
-                
+
                 return result
-                
+
             except Exception as e:
                 # 标记失败
                 context.mark_error(e)
-                logger.debug(f"异步函数 {func.__name__} 执行失败，耗时 {context.execution_time:.2f}秒")
-                
+                logger.debug(
+                    f"异步函数 {func.__name__} 执行失败，耗时 {context.execution_time:.2f}秒"
+                )
+
                 # 发送失败通知
                 if self.notify_on_error:
                     await self._send_error_notification_async(context)
-                
+
                 # 重新抛出异常
                 raise
-        
+
         return async_wrapper
-    
+
     def _send_success_notification(self, context: ExecutionContext) -> None:
         """发送成功通知（同步）"""
         try:
@@ -219,7 +227,7 @@ class NotifyDecorator:
             sender.send_notification(title, message["content"])
         except Exception as e:
             logger.warning(f"发送成功通知失败: {e}")
-    
+
     async def _send_success_notification_async(self, context: ExecutionContext) -> None:
         """发送成功通知（异步）"""
         try:
@@ -229,7 +237,7 @@ class NotifyDecorator:
             await sender.send_notification_async(title, message["content"])
         except Exception as e:
             logger.warning(f"发送成功通知失败: {e}")
-    
+
     def _send_error_notification(self, context: ExecutionContext) -> None:
         """发送错误通知（同步）"""
         try:
@@ -239,7 +247,7 @@ class NotifyDecorator:
             sender.send_notification(title, message["content"])
         except Exception as e:
             logger.warning(f"发送错误通知失败: {e}")
-    
+
     async def _send_error_notification_async(self, context: ExecutionContext) -> None:
         """发送错误通知（异步）"""
         try:
@@ -265,7 +273,8 @@ class NotifyDecorator:
                 with _decorators_lock:
                     if self._instance_id not in self._warned_missing_default:
                         logger.warning(
-                            "未提供 notify_instance 且当前执行上下文未设置默认实例，创建了一个空的 Notify 实例。请确保添加通知渠道或设置默认实例。"
+                            "未提供 notify_instance 且当前执行上下文未设置默认实例，"
+                            "创建了一个空的 Notify 实例。请确保添加通知渠道或设置默认实例。"
                         )
                         self._warned_missing_default.add(self._instance_id)
             else:
@@ -278,37 +287,49 @@ class NotifyDecorator:
             retry_backoff=self.retry_backoff,
             retriable_exceptions=self.retriable_exceptions,
         )
-    
+
     def _validate_config(self, *args) -> None:
         """验证配置参数"""
-        notify_instance, title, success_template, error_template, \
-        notify_on_success, notify_on_error, include_args, include_result, timeout, \
-        max_retries, retry_delay, retry_backoff, retriable_exceptions = args
-        
+        (
+            notify_instance,
+            title,
+            success_template,
+            error_template,
+            notify_on_success,
+            notify_on_error,
+            include_args,
+            include_result,
+            timeout,
+            max_retries,
+            retry_delay,
+            retry_backoff,
+            retriable_exceptions,
+        ) = args
+
         if notify_instance is not None and not isinstance(notify_instance, Notify):
             raise NotifyConfigError("notify_instance 必须是 Notify 类的实例")
-        
+
         if title is not None and not isinstance(title, str):
             raise NotifyConfigError("title 必须是字符串")
-        
+
         if success_template is not None and not isinstance(success_template, str):
             raise NotifyConfigError("success_template 必须是字符串")
-        
+
         if error_template is not None and not isinstance(error_template, str):
             raise NotifyConfigError("error_template 必须是字符串")
-        
+
         if not isinstance(notify_on_success, bool):
             raise NotifyConfigError("notify_on_success 必须是布尔值")
-        
+
         if not isinstance(notify_on_error, bool):
             raise NotifyConfigError("notify_on_error 必须是布尔值")
-        
+
         if not isinstance(include_args, bool):
             raise NotifyConfigError("include_args 必须是布尔值")
-        
+
         if not isinstance(include_result, bool):
             raise NotifyConfigError("include_result 必须是布尔值")
-        
+
         if timeout is not None and (not isinstance(timeout, (int, float)) or timeout <= 0):
             raise NotifyConfigError("timeout 必须是正数")
 
@@ -361,11 +382,7 @@ class NotifyDecorator:
             channels=list(notify_instance.channels),
             max_retries=retry_config.max_retries if max_retries is None else max_retries,
             retry_delay=retry_config.retry_delay if retry_delay is None else retry_delay,
-            retry_backoff=(
-                retry_config.retry_backoff
-                if retry_backoff is None
-                else retry_backoff
-            ),
+            retry_backoff=(retry_config.retry_backoff if retry_backoff is None else retry_backoff),
             retriable_exceptions=(
                 retry_config.retriable_exceptions
                 if retriable_exceptions is None
@@ -391,7 +408,7 @@ def notify(
 ) -> Callable:
     """
     创建通知装饰器的工厂函数
-    
+
     Args:
         notify_instance: Notify 实例，如果为 None 则创建空实例
         title: 自定义通知标题
@@ -406,15 +423,15 @@ def notify(
         retry_delay: 每次重试前的延迟（秒）
         retry_backoff: 重试延迟的退避倍数
         retriable_exceptions: 额外视为可重试的异常类型序列
-    
+
     Returns:
         装饰器函数
-    
+
     Example:
         @notify()
         def my_function():
             return "Hello World"
-        
+
         @notify(
             title="重要任务",
             success_template="✅ {function_name} 完成，耗时 {execution_time:.2f}秒",

--- a/src/use_notify/decorator/exceptions.py
+++ b/src/use_notify/decorator/exceptions.py
@@ -6,14 +6,17 @@
 
 class NotifyDecoratorError(Exception):
     """装饰器基础异常类"""
+
     pass
 
 
 class NotifyConfigError(NotifyDecoratorError):
     """配置错误异常"""
+
     pass
 
 
 class NotifySendError(NotifyDecoratorError):
     """通知发送错误异常"""
+
     pass

--- a/src/use_notify/decorator/formatter.py
+++ b/src/use_notify/decorator/formatter.py
@@ -12,46 +12,46 @@ from .context import ExecutionContext
 
 class MessageFormatter:
     """消息格式化器"""
-    
-    DEFAULT_SUCCESS_TEMPLATE = "✅ 函数 {function_name} 执行成功\n⏱️ 执行时间: {execution_time:.2f}秒"
-    DEFAULT_ERROR_TEMPLATE = "❌ 函数 {function_name} 执行失败\n⏱️ 执行时间: {execution_time:.2f}秒\n🚨 错误信息: {error_message}"
-    
+
+    DEFAULT_SUCCESS_TEMPLATE = (
+        "✅ 函数 {function_name} 执行成功\n⏱️ 执行时间: {execution_time:.2f}秒"
+    )
+    DEFAULT_ERROR_TEMPLATE = (
+        "❌ 函数 {function_name} 执行失败\n"
+        "⏱️ 执行时间: {execution_time:.2f}秒\n"
+        "🚨 错误信息: {error_message}"
+    )
+
     def __init__(
         self,
         success_template: Optional[str] = None,
         error_template: Optional[str] = None,
         include_args: bool = False,
-        include_result: bool = False
+        include_result: bool = False,
     ):
         self.success_template = success_template or self.DEFAULT_SUCCESS_TEMPLATE
         self.error_template = error_template or self.DEFAULT_ERROR_TEMPLATE
         self.include_args = include_args
         self.include_result = include_result
-    
+
     def format_success_message(self, context: ExecutionContext) -> Dict[str, str]:
         """格式化成功消息"""
         format_vars = self._get_format_variables(context)
         content = self.success_template.format(**format_vars)
-        
+
         if self.include_result and context.result is not None:
             result_str = self._safe_serialize(context.result)
             content += f"\n📋 返回结果: {result_str}"
-        
-        return {
-            "title": f"✅ {context.function_name} 执行成功",
-            "content": content
-        }
-    
+
+        return {"title": f"✅ {context.function_name} 执行成功", "content": content}
+
     def format_error_message(self, context: ExecutionContext) -> Dict[str, str]:
         """格式化错误消息"""
         format_vars = self._get_format_variables(context)
         content = self.error_template.format(**format_vars)
-        
-        return {
-            "title": f"❌ {context.function_name} 执行失败",
-            "content": content
-        }
-    
+
+        return {"title": f"❌ {context.function_name} 执行失败", "content": content}
+
     def _get_format_variables(self, context: ExecutionContext) -> Dict[str, Any]:
         """获取格式化变量"""
         current_time = datetime.now()
@@ -62,43 +62,43 @@ class MessageFormatter:
             "start_time": context.start_time.strftime("%Y-%m-%d %H:%M:%S"),
             "current_time": current_time.strftime("%Y-%m-%d %H:%M:%S"),
         }
-        
+
         if context.end_time:
             format_vars["end_time"] = context.end_time.strftime("%Y-%m-%d %H:%M:%S")
-        
+
         if self.include_args:
             format_vars["args"] = context.args
             format_vars["kwargs"] = context.kwargs
-            
+
             # 添加安全的参数字符串表示
             args_str = self._safe_serialize(context.args)
             kwargs_str = self._safe_serialize(context.kwargs)
             format_vars["args_str"] = args_str
             format_vars["kwargs_str"] = kwargs_str
-        
+
         if context.result is not None:
             format_vars["result"] = context.result
             format_vars["result_str"] = self._safe_serialize(context.result)
-        
+
         return format_vars
-    
+
     def _safe_serialize(self, obj: Any, max_length: int = 200) -> str:
         """安全序列化对象为字符串"""
         try:
             if obj is None:
                 return "None"
-            
+
             # 尝试 JSON 序列化
             try:
                 result = json.dumps(obj, ensure_ascii=False, default=str)
             except (TypeError, ValueError):
                 # 如果 JSON 序列化失败，使用 str()
                 result = str(obj)
-            
+
             # 限制长度
             if len(result) > max_length:
                 result = result[:max_length] + "..."
-            
+
             return result
         except Exception:
             return "<无法序列化>"

--- a/src/use_notify/decorator/sender.py
+++ b/src/use_notify/decorator/sender.py
@@ -5,11 +5,11 @@
 
 import asyncio
 import logging
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Optional
 
 from ..notification import Notify
-
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +17,7 @@ logger = logging.getLogger(__name__)
 class NotificationSender:
     """通知发送器"""
 
-    def __init__(
-        self,
-        notify_instance: Notify,
-        timeout: Optional[float] = None
-    ):
+    def __init__(self, notify_instance: Notify, timeout: Optional[float] = None):
         self.notify_instance = notify_instance
         self.timeout = timeout
 
@@ -57,8 +53,7 @@ class NotificationSender:
         try:
             if self.timeout:
                 await asyncio.wait_for(
-                    self._send_async_internal(title, content),
-                    timeout=self.timeout
+                    self._send_async_internal(title, content), timeout=self.timeout
                 )
             else:
                 await self._send_async_internal(title, content)

--- a/src/use_notify/notification.py
+++ b/src/use_notify/notification.py
@@ -8,8 +8,8 @@ from threading import RLock
 from typing import List, Optional, Tuple, Type, TypeVar
 
 import httpx
-from use_notify import channels as channels_models
 
+from use_notify import channels as channels_models
 
 logger = logging.getLogger(__name__)
 RetriableExceptions = Tuple[Type[BaseException], ...]
@@ -40,13 +40,10 @@ class RetryConfig:
         invalid_exceptions = [
             exception_type
             for exception_type in self.retriable_exceptions
-            if not isinstance(exception_type, type)
-            or not issubclass(exception_type, BaseException)
+            if not isinstance(exception_type, type) or not issubclass(exception_type, BaseException)
         ]
         if invalid_exceptions:
-            raise ValueError(
-                "retriable_exceptions must only contain exception types"
-            )
+            raise ValueError("retriable_exceptions must only contain exception types")
 
 
 class NotificationPublishError(RuntimeError):
@@ -54,9 +51,7 @@ class NotificationPublishError(RuntimeError):
 
     def __init__(self, failures: List[Tuple[str, Exception]]):
         self.failures = failures
-        failure_summary = ", ".join(
-            f"{channel_name}: {error}" for channel_name, error in failures
-        )
+        failure_summary = ", ".join(f"{channel_name}: {error}" for channel_name, error in failures)
         super().__init__(f"Failed to publish notification via: {failure_summary}")
 
 
@@ -178,9 +173,7 @@ class Publisher:
                     time.sleep(delay)
                 delay *= retry_config.retry_backoff
 
-    async def _send_with_retry_async(
-        self, channel, retry_config: RetryConfig, *args, **kwargs
-    ):
+    async def _send_with_retry_async(self, channel, retry_config: RetryConfig, *args, **kwargs):
         max_attempts = retry_config.max_retries + 1
         delay = retry_config.retry_delay
 
@@ -234,9 +227,7 @@ class Publisher:
             raise failures[0][1]
         raise NotificationPublishError(failures)
 
-    def _is_retriable_exception(
-        self, error: Exception, retry_config: RetryConfig
-    ) -> bool:
+    def _is_retriable_exception(self, error: Exception, retry_config: RetryConfig) -> bool:
         if isinstance(error, httpx.HTTPStatusError):
             if error.response is None:
                 return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
 from tests.helpers import RecordingChannel, make_http_status_error
 
-
 __all__ = ["RecordingChannel", "make_http_status_error"]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,9 +1,10 @@
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from tests.helpers import RecordingChannel
 from use_notify import (
     clear_default_notify_instance,
     get_default_notify_instance,
@@ -12,8 +13,6 @@ from use_notify import (
     useNotify,
 )
 from use_notify.decorator import NotifyConfigError, NotifyDecorator
-
-from tests.helpers import RecordingChannel
 
 
 class TestNotifyDecorator:
@@ -230,6 +229,7 @@ class TestNotifyDecorator:
             return "ok"
 
         import asyncio
+
         start = asyncio.get_event_loop().time()
 
         # 在异步上下文中调用同步装饰器
@@ -257,6 +257,7 @@ class TestNotifyDecorator:
     @pytest.mark.asyncio
     async def test_async_timeout_works(self):
         """测试异步超时正常工作"""
+
         class SlowChannel(RecordingChannel):
             async def send_async(self, content, title=None):
                 await asyncio.sleep(2)
@@ -278,5 +279,3 @@ class TestNotifyDecorator:
         assert elapsed < 0.5, f"函数执行时间 {elapsed:.2f}s 超过预期"
         # 超时应该生效，通知发送失败
         assert len(channel.async_messages) == 0
-
-

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,11 +1,8 @@
-import asyncio
-import smtplib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from use_notify import useNotifyChannel
-
 
 EMAIL_CONFIG = {
     "server": "smtp.gmail.com",

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -5,10 +5,9 @@ import httpx
 import pytest
 
 import use_notify.notification as notification_module
+from tests.helpers import RecordingChannel, make_http_status_error
 from use_notify import NotificationPublishError, useNotify, useNotifyChannel
 from use_notify.notification import Publisher, RetryConfig
-
-from tests.helpers import RecordingChannel, make_http_status_error
 
 
 class BlockingSyncChannel(RecordingChannel):
@@ -172,9 +171,7 @@ async def test_publisher_add_does_not_affect_in_flight_async_publish():
 
 
 def test_configure_retry_does_not_affect_in_flight_publish(monkeypatch):
-    channel = RecordingChannel(
-        sync_failures=[RuntimeError("temporary"), RuntimeError("temporary")]
-    )
+    channel = RecordingChannel(sync_failures=[RuntimeError("temporary"), RuntimeError("temporary")])
     publisher = Publisher(
         [channel],
         max_retries=2,


### PR DESCRIPTION
## Summary

- Add compatible `black`, `isort`, and `flake8` configuration.
- Format source, tests, and examples so `make lint` passes.
- Add `make lint` to the GitHub Actions test workflow.
- Pin Black target version to Python 3.8 so CI formatting is stable across Python 3.8, 3.9, and 3.10.

Closes #17

## Verification

- `make lint`
- `uv run --group dev pytest -q tests`
- `uv run --python 3.8 --group dev isort --check .`
- `uv run --python 3.8 --group dev black --check .`
- `uv run --python 3.8 --group dev flake8 src tests`
- `uv run --python 3.10 --group dev isort --check .`
- `uv run --python 3.10 --group dev black --check .`
- `uv run --python 3.10 --group dev flake8 src tests`
