### PR TITLE
Detect provider business errors

### DIFF
--- a/src/use_notify/channels/bark.py
+++ b/src/use_notify/channels/bark.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from .base import BaseChannel
+from .utils import validate_business_response
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ class Bark(BaseChannel):
         with httpx.Client() as client:
             response = client.post(self.api_url, headers=self.headers, json=payload)
             response.raise_for_status()
+            validate_business_response(response, "bark", {"code": {200}})
         logger.debug("`bark` send successfully")
 
     async def send_async(self, content, title=None):
@@ -52,4 +54,5 @@ class Bark(BaseChannel):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.api_url, headers=self.headers, json=payload)
             response.raise_for_status()
+            validate_business_response(response, "bark", {"code": {200}})
         logger.debug("`bark` send successfully")

--- a/src/use_notify/channels/chanify.py
+++ b/src/use_notify/channels/chanify.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from .base import BaseChannel
+from .utils import validate_business_response
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ class Chanify(BaseChannel):
         with httpx.Client() as client:
             response = client.post(self.api_url, data=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "chanify", {"res": {0}, "code": {0}})
         logger.debug("`chanify` send successfully")
 
     async def send_async(self, content, title=None):
@@ -41,4 +43,5 @@ class Chanify(BaseChannel):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.api_url, data=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "chanify", {"res": {0}, "code": {0}})
         logger.debug("`chanify` send successfully")

--- a/src/use_notify/channels/ding.py
+++ b/src/use_notify/channels/ding.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from .base import BaseChannel
+from .utils import validate_business_response
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ class Ding(BaseChannel):
         with httpx.Client() as client:
             response = client.post(self.api_url, json=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "ding", {"errcode": {0}})
         logger.debug("`钉钉` send successfully")
 
     async def send_async(self, content, title=None):
@@ -48,4 +50,5 @@ class Ding(BaseChannel):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.api_url, json=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "ding", {"errcode": {0}})
         logger.debug("`钉钉` send successfully")

--- a/src/use_notify/channels/feishu.py
+++ b/src/use_notify/channels/feishu.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from .base import BaseChannel
+from .utils import validate_business_response
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class Feishu(BaseChannel):
         with httpx.Client() as client:
             response = client.post(self.api_url, json=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "feishu", {"code": {0}})
         logger.debug("`飞书` send successfully")
 
     async def send_async(self, content, title=None):
@@ -49,4 +51,5 @@ class Feishu(BaseChannel):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.api_url, json=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "feishu", {"code": {0}})
         logger.debug("`飞书` send successfully")

--- a/src/use_notify/channels/pushdeer.py
+++ b/src/use_notify/channels/pushdeer.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from .base import BaseChannel
+from .utils import validate_business_response
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,7 @@ class PushDeer(BaseChannel):
         with httpx.Client() as client:
             response = client.get(self.api_url, params=params, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "pushdeer", {"code": {0}})
         logger.debug("`pushdeer` send message successfully")
 
     async def send_async(self, content, title=None):
@@ -104,4 +106,5 @@ class PushDeer(BaseChannel):
         async with httpx.AsyncClient() as client:
             response = await client.get(self.api_url, params=params, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "pushdeer", {"code": {0}})
         logger.debug("`pushdeer` send message successfully")

--- a/src/use_notify/channels/pushover.py
+++ b/src/use_notify/channels/pushover.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from .base import BaseChannel
+from .utils import validate_business_response
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ class PushOver(BaseChannel):
         with httpx.Client() as client:
             response = client.post(self.api_url, data=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "pushover", {"status": {1}})
         logger.debug("`pushover` send successfully")
 
     async def send_async(self, content, title=None):
@@ -39,4 +41,5 @@ class PushOver(BaseChannel):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.api_url, data=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "pushover", {"status": {1}})
         logger.debug("`pushover` send successfully")

--- a/src/use_notify/channels/utils.py
+++ b/src/use_notify/channels/utils.py
@@ -1,0 +1,62 @@
+import json
+from typing import Dict, Iterable
+
+
+class ProviderResponseError(RuntimeError):
+    """Raised when a provider returns HTTP success with a failure payload."""
+
+    def __init__(self, provider: str, field: str, value, detail: str):
+        self.provider = provider
+        self.field = field
+        self.value = value
+        self.detail = detail
+        super().__init__(
+            f"{provider} notification provider rejected response " f"({field}={value!r}): {detail}"
+        )
+
+
+def validate_business_response(
+    response,
+    provider: str,
+    success_fields: Dict[str, Iterable],
+) -> None:
+    """Validate provider-specific success fields in a JSON response body."""
+    try:
+        payload = response.json()
+    except (TypeError, ValueError):
+        return
+
+    if not isinstance(payload, dict):
+        return
+
+    for field, success_values in success_fields.items():
+        if field not in payload:
+            continue
+        if payload[field] not in set(success_values):
+            raise ProviderResponseError(
+                provider=provider,
+                field=field,
+                value=payload[field],
+                detail=_extract_error_detail(payload),
+            )
+
+
+def _extract_error_detail(payload: dict) -> str:
+    for key in (
+        "errmsg",
+        "msg",
+        "message",
+        "error",
+        "error_description",
+        "desc",
+        "errors",
+    ):
+        value = payload.get(key)
+        if value:
+            if isinstance(value, (list, tuple)):
+                return ", ".join(str(item) for item in value)
+            if isinstance(value, dict):
+                return json.dumps(value, ensure_ascii=False, sort_keys=True)
+            return str(value)
+
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)

--- a/src/use_notify/channels/wechat.py
+++ b/src/use_notify/channels/wechat.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from .base import BaseChannel
+from .utils import validate_business_response
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ class WeChat(BaseChannel):
         with httpx.Client() as client:
             response = client.post(self.api_url, json=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "wechat", {"errcode": {0}})
         logger.debug("`WeChat` send successfully")
 
     async def send_async(self, content, title=None):
@@ -42,4 +44,5 @@ class WeChat(BaseChannel):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.api_url, json=api_body, headers=self.headers)
             response.raise_for_status()
+            validate_business_response(response, "wechat", {"errcode": {0}})
         logger.debug("`WeChat` send successfully")

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -5,15 +5,23 @@ import pytest
 from use_notify import useNotifyChannel
 
 
-def _mock_sync_http_response():
+def _mock_sync_http_response(json_data=None):
     response = MagicMock()
     response.raise_for_status = MagicMock()
+    if json_data is not None:
+        response.json.return_value = json_data
+    else:
+        response.json.side_effect = ValueError("response body is not JSON")
     return response
 
 
-def _mock_async_http_response():
+def _mock_async_http_response(json_data=None):
     response = MagicMock()
     response.raise_for_status = MagicMock()
+    if json_data is not None:
+        response.json.return_value = json_data
+    else:
+        response.json.side_effect = ValueError("response body is not JSON")
     return response
 
 
@@ -85,6 +93,17 @@ def test_ding_build_api_body_includes_mentions():
     }
 
 
+@patch("httpx.Client")
+def test_ding_send_rejects_business_error_response(mock_client):
+    response = _mock_sync_http_response({"errcode": 310000, "errmsg": "invalid token"})
+    client = mock_client.return_value.__enter__.return_value
+    client.post.return_value = response
+    channel = useNotifyChannel.Ding({"token": "token"})
+
+    with pytest.raises(RuntimeError, match="ding.*invalid token"):
+        channel.send("hello", "title")
+
+
 def test_feishu_build_api_body_includes_mentions():
     channel = useNotifyChannel.Feishu(
         {
@@ -101,6 +120,17 @@ def test_feishu_build_api_body_includes_mentions():
     assert {"tag": "text", "text": "hello"} in content
     assert {"tag": "at", "user_id": "all"} in content
     assert {"tag": "at", "user_id": "ou_xxx"} in content
+
+
+@patch("httpx.Client")
+def test_feishu_send_rejects_business_error_response(mock_client):
+    response = _mock_sync_http_response({"code": 9499, "msg": "bad webhook"})
+    client = mock_client.return_value.__enter__.return_value
+    client.post.return_value = response
+    channel = useNotifyChannel.Feishu({"token": "token"})
+
+    with pytest.raises(RuntimeError, match="feishu.*bad webhook"):
+        channel.send("hello", "title")
 
 
 def test_wechat_build_api_body_includes_mentions():
@@ -122,6 +152,17 @@ def test_wechat_build_api_body_includes_mentions():
         },
         "msgtype": "markdown",
     }
+
+
+@patch("httpx.Client")
+def test_wechat_send_rejects_business_error_response(mock_client):
+    response = _mock_sync_http_response({"errcode": 40001, "errmsg": "invalid credential"})
+    client = mock_client.return_value.__enter__.return_value
+    client.post.return_value = response
+    channel = useNotifyChannel.WeChat({"token": "token"})
+
+    with pytest.raises(RuntimeError, match="wechat.*invalid credential"):
+        channel.send("hello", "title")
 
 
 def test_ntfy_requires_topic_and_builds_payload():
@@ -167,6 +208,17 @@ def test_pushdeer_prepare_params_handles_markdown_and_invalid_type(caplog):
 
 
 @patch("httpx.Client")
+def test_pushdeer_send_rejects_business_error_response(mock_client):
+    response = _mock_sync_http_response({"code": 80403, "error": "pushkey invalid"})
+    client = mock_client.return_value.__enter__.return_value
+    client.get.return_value = response
+    channel = useNotifyChannel.PushDeer({"token": "token"})
+
+    with pytest.raises(RuntimeError, match="pushdeer.*pushkey invalid"):
+        channel.send("hello", "title")
+
+
+@patch("httpx.Client")
 def test_pushover_send_builds_expected_request(mock_client):
     response = _mock_sync_http_response()
     client = mock_client.return_value.__enter__.return_value
@@ -181,6 +233,40 @@ def test_pushover_send_builds_expected_request(mock_client):
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     response.raise_for_status.assert_called_once_with()
+
+
+@patch("httpx.Client")
+def test_pushover_send_rejects_business_error_response(mock_client):
+    response = _mock_sync_http_response({"status": 0, "errors": ["bad user"]})
+    client = mock_client.return_value.__enter__.return_value
+    client.post.return_value = response
+    channel = useNotifyChannel.PushOver({"token": "app", "user": "user"})
+
+    with pytest.raises(RuntimeError, match="pushover.*bad user"):
+        channel.send("hello", "title")
+
+
+@patch("httpx.Client")
+def test_bark_send_rejects_business_error_response(mock_client):
+    response = _mock_sync_http_response({"code": 400, "message": "bad device token"})
+    client = mock_client.return_value.__enter__.return_value
+    client.post.return_value = response
+    channel = useNotifyChannel.Bark({"token": "token"})
+
+    with pytest.raises(RuntimeError, match="bark.*bad device token"):
+        channel.send("hello", "title")
+
+
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_chanify_send_async_rejects_business_error_response(mock_client):
+    response = _mock_async_http_response({"res": 1, "msg": "invalid token"})
+    client = mock_client.return_value.__aenter__.return_value
+    client.post = AsyncMock(return_value=response)
+    channel = useNotifyChannel.Chanify({"token": "token"})
+
+    with pytest.raises(RuntimeError, match="chanify.*invalid token"):
+        await channel.send_async("hello", "title")
 
 
 def test_console_send_outputs_message(capsys):


### PR DESCRIPTION
## Summary

- Add shared provider business response validation.
- Reject HTTP 200 responses that contain provider-level failure payloads.
- Cover Ding, WeChat, Feishu, PushDeer, PushOver, Bark, and Chanify paths.
- Add regression tests for sync and async provider business failures.

Closes #18

## Verification

- `uv run --group dev pytest -q tests/test_channels.py -k business_error`
- `uv run --group dev pytest -v tests/test_channels.py`
- `uv run --group dev pytest -v tests`
- `make lint`
