### PR TITLE
Bound sync timeout delivery

### DIFF
--- a/skill-references/troubleshooting.md
+++ b/skill-references/troubleshooting.md
@@ -55,7 +55,9 @@ Non-retriable examples include:
 ## Timeout behavior
 
 - Decorator `timeout` applies to notification delivery, not to the wrapped business function.
-- Sync delivery uses a short-lived thread pool to avoid blocking the caller forever.
+- Sync delivery uses a bounded background worker pool. A timed-out sync send cannot be
+  force-cancelled safely and may still finish later, but at most four timed-out sync sends
+  can continue in the background at once.
 - Async delivery uses `asyncio.wait_for(...)`.
 
 ## Validation pitfalls

--- a/src/use_notify/decorator/sender.py
+++ b/src/use_notify/decorator/sender.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import logging
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Optional
@@ -17,6 +18,13 @@ logger = logging.getLogger(__name__)
 class NotificationSender:
     """通知发送器"""
 
+    SYNC_TIMEOUT_WORKERS = 4
+    _sync_timeout_executor = ThreadPoolExecutor(
+        max_workers=SYNC_TIMEOUT_WORKERS,
+        thread_name_prefix="use-notify-sync-timeout",
+    )
+    _sync_timeout_slots = threading.BoundedSemaphore(SYNC_TIMEOUT_WORKERS)
+
     def __init__(self, notify_instance: Notify, timeout: Optional[float] = None):
         self.notify_instance = notify_instance
         self.timeout = timeout
@@ -25,17 +33,9 @@ class NotificationSender:
         """发送同步通知"""
         try:
             if self.timeout:
-                # 使用线程池执行同步调用，实现超时控制
-                # 无论是否在异步事件循环中，都能正确应用超时
-                executor = ThreadPoolExecutor(max_workers=1)
-                try:
-                    future = executor.submit(
-                        self.notify_instance.publish, title=title, content=content
-                    )
-                    future.result(timeout=self.timeout)
-                finally:
-                    # 使用 shutdown(wait=False) 立即关闭线程池，不等待线程完成
-                    executor.shutdown(wait=False)
+                # Python cannot stop a running sync send safely. Keep timed-out
+                # work bounded so callers return quickly without unbounded threads.
+                self._send_sync_with_timeout(title, content)
             else:
                 self.notify_instance.publish(title=title, content=content)
 
@@ -66,6 +66,31 @@ class NotificationSender:
     async def _send_async_internal(self, title: str, content: str) -> None:
         """内部异步发送方法"""
         await self.notify_instance.publish_async(title=title, content=content)
+
+    def _send_sync_with_timeout(self, title: str, content: str) -> None:
+        if not self._sync_timeout_slots.acquire(blocking=False):
+            raise asyncio.TimeoutError(
+                f"同步通知后台 worker 已满（最多 {self.SYNC_TIMEOUT_WORKERS} 个）"
+            )
+
+        try:
+            future = self._sync_timeout_executor.submit(
+                self.notify_instance.publish, title=title, content=content
+            )
+        except Exception:
+            self._sync_timeout_slots.release()
+            raise
+
+        future.add_done_callback(self._release_sync_timeout_slot)
+        try:
+            future.result(timeout=self.timeout)
+        except FutureTimeoutError:
+            future.cancel()
+            raise
+
+    @classmethod
+    def _release_sync_timeout_slot(cls, _future) -> None:
+        cls._sync_timeout_slots.release()
 
     def _handle_send_error(self, error: Exception) -> None:
         """处理发送错误"""

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -13,6 +13,7 @@ from use_notify import (
     useNotify,
 )
 from use_notify.decorator import NotifyConfigError, NotifyDecorator
+from use_notify.decorator.sender import NotificationSender
 
 
 class TestNotifyDecorator:
@@ -190,9 +191,11 @@ class TestNotifyDecorator:
         """测试同步超时不阻塞主线程"""
         import time
 
+        release = threading.Event()
+
         class SlowChannel(RecordingChannel):
             def send(self, content, title=None):
-                time.sleep(2)
+                release.wait(timeout=1)
                 super().send(content, title)
 
         channel = SlowChannel()
@@ -202,23 +205,26 @@ class TestNotifyDecorator:
         def task():
             return "ok"
 
-        start = time.time()
-        result = task()
-        elapsed = time.time() - start
+        try:
+            start = time.time()
+            result = task()
+            elapsed = time.time() - start
 
-        # 函数应该立即返回，不等待2秒
-        assert result == "ok"
-        assert elapsed < 0.5, f"函数执行时间 {elapsed:.2f}s 超过预期"
-        # 超时错误应该被记录（不抛出，避免影响原函数执行）
+            # 函数应该立即返回，不等待后台发送
+            assert result == "ok"
+            assert elapsed < 0.5, f"函数执行时间 {elapsed:.2f}s 超过预期"
+            # 超时错误应该被记录（不抛出，避免影响原函数执行）
+        finally:
+            release.set()
 
     @pytest.mark.asyncio
     async def test_sync_timeout_in_async_event_loop(self):
         """测试同步超时在异步事件循环中也能正确应用"""
-        import time
+        release = threading.Event()
 
         class SlowChannel(RecordingChannel):
             def send(self, content, title=None):
-                time.sleep(2)
+                release.wait(timeout=1)
                 super().send(content, title)
 
         channel = SlowChannel()
@@ -230,16 +236,56 @@ class TestNotifyDecorator:
 
         import asyncio
 
-        start = asyncio.get_event_loop().time()
+        try:
+            start = asyncio.get_event_loop().time()
 
-        # 在异步上下文中调用同步装饰器
-        result = sync_task()
+            # 在异步上下文中调用同步装饰器
+            result = sync_task()
 
-        elapsed = asyncio.get_event_loop().time() - start
+            elapsed = asyncio.get_event_loop().time() - start
 
-        # 函数应该立即返回，不等待2秒
-        assert result == "ok"
-        assert elapsed < 0.5, f"函数执行时间 {elapsed:.2f}s 超过预期"
+            # 函数应该立即返回，不等待后台发送
+            assert result == "ok"
+            assert elapsed < 0.5, f"函数执行时间 {elapsed:.2f}s 超过预期"
+        finally:
+            release.set()
+
+    def test_sync_timeout_background_delivery_is_bounded(self):
+        """同步超时发送最多占用固定数量的后台 worker"""
+
+        release = threading.Event()
+        started_limit = threading.Event()
+        lock = threading.Lock()
+
+        class BlockingChannel(RecordingChannel):
+            def __init__(self):
+                super().__init__()
+                self.started_count = 0
+
+            def send(self, content, title=None):
+                with lock:
+                    self.started_count += 1
+                    if self.started_count >= NotificationSender.SYNC_TIMEOUT_WORKERS:
+                        started_limit.set()
+
+                release.wait(timeout=2)
+                super().send(content, title)
+
+        channel = BlockingChannel()
+        notify_instance = useNotify([channel])
+
+        @notify(notify_instance=notify_instance, timeout=0.01)
+        def task():
+            return "ok"
+
+        try:
+            for _ in range(NotificationSender.SYNC_TIMEOUT_WORKERS + 2):
+                assert task() == "ok"
+
+            assert started_limit.wait(timeout=1)
+            assert channel.started_count == NotificationSender.SYNC_TIMEOUT_WORKERS
+        finally:
+            release.set()
 
     def test_sync_send_without_timeout(self):
         """测试不设置超时时正常发送"""


### PR DESCRIPTION
## Summary

- Replace one executor per timed-out sync notification with a bounded shared worker pool.
- Keep sync timeout semantics explicit: callers return quickly, but running sync sends are best-effort and may finish later.
- Add regression coverage proving background sync timeout delivery is capped.
- Update troubleshooting docs for the bounded best-effort behavior.

Closes #19

## Verification

- `uv run --group dev pytest -v tests/test_decorator.py`
- `uv run --group dev pytest -v tests`
- `make lint`
