### PR TITLE
Make email delivery lazy and TLS-aware

### DIFF
--- a/skill-references/channels.md
+++ b/skill-references/channels.md
@@ -70,9 +70,14 @@ useNotifyChannel.Email(
         "password": "app-password",
         "from_email": "bot@example.com",
         "to_emails": ["ops@example.com"],
+        "use_ssl": True,
+        "use_tls": False,
     }
 )
 ```
+
+For port `465`, SSL is used by default. For port `587`, STARTTLS is used by
+default unless `use_ssl` or `use_tls` is set explicitly.
 
 ### Chanify
 

--- a/skill-references/troubleshooting.md
+++ b/skill-references/troubleshooting.md
@@ -67,7 +67,10 @@ Non-retriable examples include:
 - `retry_delay` must be `>= 0`.
 - `retry_backoff` must be `> 0`.
 - `retriable_exceptions` must contain exception types, not strings or instances.
-- `Email` requires `server`, `port`, `username`, `password`, and `from_email` during initialization.
+- `Email` validates `server`, `port`, `username`, `password`, and `from_email`
+  during initialization, then connects and logs in when a message is sent.
+- `Email` uses SSL by default on port `465` and STARTTLS by default on port `587`;
+  set `use_ssl` or `use_tls` explicitly to override that behavior.
 
 ## Current public exports
 

--- a/src/use_notify/channels/email.py
+++ b/src/use_notify/channels/email.py
@@ -17,9 +17,6 @@ class Email(BaseChannel):
     def __init__(self, config):
         super().__init__(config)
         self._validate_required_fields()
-        self.smtp = smtplib.SMTP_SSL(self.config.server, self.config.port)
-        self.smtp.connect(self.config.server, self.config.port)
-        self.smtp.login(self.config.username, self.config.password)
 
     def _validate_required_fields(self):
         """校验必填字段"""
@@ -61,7 +58,7 @@ class Email(BaseChannel):
             return
         message = self.build_message(content, title)
 
-        self.smtp.sendmail(self.config.from_email, self.config.to_emails, message)
+        self._send_message(message)
         logger.debug("邮件通知推送成功")
 
     async def send_async(self, content, title=None):
@@ -70,9 +67,45 @@ class Email(BaseChannel):
             return
         message = self.build_message(content, title)
 
-        loop = asyncio.get_event_loop()
-        sendmail_func = partial(
-            self.smtp.sendmail, self.config.from_email, self.config.to_emails, message
-        )
+        loop = asyncio.get_running_loop()
+        sendmail_func = partial(self._send_message, message)
         await loop.run_in_executor(None, sendmail_func)
         logger.debug("邮件通知推送成功")
+
+    def _send_message(self, message):
+        smtp = self._connect()
+        try:
+            smtp.sendmail(self.config.from_email, self.config.to_emails, message)
+        finally:
+            self._close(smtp)
+
+    def _connect(self):
+        port = int(self.config.port)
+        if self._use_ssl(port):
+            smtp = smtplib.SMTP_SSL(self.config.server, port)
+        else:
+            smtp = smtplib.SMTP(self.config.server, port)
+            if self._use_tls(port):
+                smtp.starttls()
+
+        smtp.login(self.config.username, self.config.password)
+        return smtp
+
+    def _use_ssl(self, port: int) -> bool:
+        if "use_ssl" in self.config:
+            return bool(self.config.use_ssl)
+        if "use_tls" in self.config and self.config.use_tls:
+            return False
+        return port == 465
+
+    def _use_tls(self, port: int) -> bool:
+        if "use_tls" in self.config:
+            return bool(self.config.use_tls)
+        return not self._use_ssl(port) and port == 587
+
+    @staticmethod
+    def _close(smtp):
+        try:
+            smtp.quit()
+        except (OSError, smtplib.SMTPException):
+            smtp.close()

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -6,7 +6,7 @@ from use_notify import useNotifyChannel
 
 EMAIL_CONFIG = {
     "server": "smtp.gmail.com",
-    "port": 587,
+    "port": 465,
     "username": "user@example.com",
     "password": "secret",
     "from_email": "sender@example.com",
@@ -15,14 +15,12 @@ EMAIL_CONFIG = {
 
 
 @patch("smtplib.SMTP_SSL")
-def test_email_initializes_and_logs_in(mock_smtp):
-    smtp = mock_smtp.return_value
-
+@patch("smtplib.SMTP")
+def test_email_initialization_is_lazy(mock_smtp, mock_smtp_ssl):
     channel = useNotifyChannel.Email(EMAIL_CONFIG)
 
-    mock_smtp.assert_called_once_with("smtp.gmail.com", 587)
-    smtp.connect.assert_called_once_with("smtp.gmail.com", 587)
-    smtp.login.assert_called_once_with("user@example.com", "secret")
+    mock_smtp.assert_not_called()
+    mock_smtp_ssl.assert_not_called()
     assert channel.config.from_email == "sender@example.com"
 
 
@@ -35,27 +33,51 @@ def test_email_validates_required_fields():
 
 
 @patch("smtplib.SMTP_SSL")
-def test_email_send_uses_sendmail(mock_smtp):
-    smtp = mock_smtp.return_value
+def test_email_send_uses_ssl_sendmail_and_quits(mock_smtp_ssl):
+    smtp = mock_smtp_ssl.return_value
     channel = useNotifyChannel.Email(EMAIL_CONFIG)
 
     channel.send("hello", "title")
 
+    mock_smtp_ssl.assert_called_once_with("smtp.gmail.com", 465)
+    smtp.login.assert_called_once_with("user@example.com", "secret")
     smtp.sendmail.assert_called_once()
     args = smtp.sendmail.call_args[0]
     assert args[0] == "sender@example.com"
     assert args[1] == ["receiver@example.com"]
     assert "title" in args[2]
+    smtp.quit.assert_called_once_with()
+
+
+@patch("smtplib.SMTP")
+def test_email_send_uses_starttls_when_configured(mock_smtp):
+    smtp = mock_smtp.return_value
+    channel = useNotifyChannel.Email(
+        {
+            **EMAIL_CONFIG,
+            "port": 587,
+            "use_ssl": False,
+            "use_tls": True,
+        }
+    )
+
+    channel.send("hello", "title")
+
+    mock_smtp.assert_called_once_with("smtp.gmail.com", 587)
+    smtp.starttls.assert_called_once_with()
+    smtp.login.assert_called_once_with("user@example.com", "secret")
+    smtp.sendmail.assert_called_once()
+    smtp.quit.assert_called_once_with()
 
 
 @patch("smtplib.SMTP_SSL")
-@patch("asyncio.get_event_loop")
+@patch("asyncio.get_running_loop")
 @pytest.mark.asyncio
-async def test_email_send_async_uses_executor(mock_get_event_loop, mock_smtp):
-    smtp = mock_smtp.return_value
+async def test_email_send_async_uses_executor(mock_get_running_loop, mock_smtp_ssl):
+    smtp = mock_smtp_ssl.return_value
     loop = MagicMock()
     loop.run_in_executor = AsyncMock(return_value=None)
-    mock_get_event_loop.return_value = loop
+    mock_get_running_loop.return_value = loop
     channel = useNotifyChannel.Email(EMAIL_CONFIG)
 
     await channel.send_async("hello", "title")
@@ -67,10 +89,13 @@ async def test_email_send_async_uses_executor(mock_get_event_loop, mock_smtp):
 
 
 @patch("smtplib.SMTP_SSL")
+@patch("smtplib.SMTP")
 @patch("use_notify.channels.email.logger")
-def test_email_send_without_receivers_only_logs(mock_logger, mock_smtp):
+def test_email_send_without_receivers_only_logs(mock_logger, mock_smtp, mock_smtp_ssl):
     channel = useNotifyChannel.Email({k: v for k, v in EMAIL_CONFIG.items() if k != "to_emails"})
 
     channel.send("hello")
 
     mock_logger.error.assert_called_once_with("请先设置接收邮箱<to_emails>")
+    mock_smtp.assert_not_called()
+    mock_smtp_ssl.assert_not_called()


### PR DESCRIPTION
## Summary

- Make Email construction lazy: validate config without connecting or logging in.
- Connect and authenticate at send time.
- Support SSL and STARTTLS with sensible defaults for ports 465 and 587.
- Quit SMTP sessions after send with close fallback.
- Update channel/troubleshooting docs for the new Email behavior.

Closes #20

## Verification

- `uv run --group dev pytest -v tests/test_email.py`
- `uv run --group dev pytest -v tests`
- `make lint`
