### PR TITLE
Redact notification secrets in errors

### DIFF
--- a/src/use_notify/notification.py
+++ b/src/use_notify/notification.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Tuple, Type, TypeVar
 import httpx
 
 from use_notify import channels as channels_models
+from use_notify.redaction import redact_exception_message, redact_text
 
 logger = logging.getLogger(__name__)
 RetriableExceptions = Tuple[Type[BaseException], ...]
@@ -51,7 +52,9 @@ class NotificationPublishError(RuntimeError):
 
     def __init__(self, failures: List[Tuple[str, Exception]]):
         self.failures = failures
-        failure_summary = ", ".join(f"{channel_name}: {error}" for channel_name, error in failures)
+        failure_summary = ", ".join(
+            f"{channel_name}: {redact_text(str(error))}" for channel_name, error in failures
+        )
         super().__init__(f"Failed to publish notification via: {failure_summary}")
 
 
@@ -224,7 +227,7 @@ class Publisher:
     @staticmethod
     def _raise_publish_error(failures):
         if len(failures) == 1:
-            raise failures[0][1]
+            raise redact_exception_message(failures[0][1])
         raise NotificationPublishError(failures)
 
     def _is_retriable_exception(self, error: Exception, retry_config: RetryConfig) -> bool:

--- a/src/use_notify/redaction.py
+++ b/src/use_notify/redaction.py
@@ -1,0 +1,28 @@
+import re
+
+SECRET_REPLACEMENT = "<redacted>"
+
+_QUERY_SECRET_RE = re.compile(r"(?i)([?&](?:access_token|token|key|pushkey)=)[^&\s)]+")
+_PATH_SECRET_PATTERNS = (
+    re.compile(r"(?i)(api\.day\.app/)[^/?\s)]+"),
+    re.compile(r"(?i)(/v1/sender/)[^/?\s)]+"),
+    re.compile(r"(?i)(/open-apis/bot/v2/hook/)[^/?\s)]+"),
+    re.compile(r"(?i)(ntfy\.sh/)[^/?\s)]+"),
+)
+
+
+def redact_text(value: str) -> str:
+    """Redact common notification provider secrets from text."""
+    redacted = _QUERY_SECRET_RE.sub(rf"\1{SECRET_REPLACEMENT}", value)
+    for pattern in _PATH_SECRET_PATTERNS:
+        redacted = pattern.sub(rf"\1{SECRET_REPLACEMENT}", redacted)
+    return redacted
+
+
+def redact_exception_message(error: Exception) -> Exception:
+    """Redact string args in an exception while preserving its type and attrs."""
+    if not error.args:
+        return error
+
+    error.args = tuple(redact_text(arg) if isinstance(arg, str) else arg for arg in error.args)
+    return error

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -109,6 +109,50 @@ def test_publisher_aggregates_failures_after_other_channels_continue():
     assert len(error_info.value.failures) == 2
 
 
+def test_single_channel_failure_redacts_secret_from_exception_message():
+    request = httpx.Request(
+        "POST",
+        "https://oapi.dingtalk.com/robot/send?access_token=ding-secret-token",
+    )
+    response = httpx.Response(500, request=request)
+    channel_error = httpx.HTTPStatusError(
+        "request failed for " "https://oapi.dingtalk.com/robot/send?access_token=ding-secret-token",
+        request=request,
+        response=response,
+    )
+    channel = RecordingChannel(sync_failures=[channel_error])
+    publisher = Publisher([channel])
+
+    with pytest.raises(httpx.HTTPStatusError) as error_info:
+        publisher.publish("hello")
+
+    message = str(error_info.value)
+    assert "ding-secret-token" not in message
+    assert "access_token=<redacted>" in message
+
+
+def test_aggregate_failure_redacts_secrets_from_exception_message():
+    failing_one = RecordingChannel(
+        sync_failures=[RuntimeError("failed https://api.day.app/bark-secret-token")]
+    )
+    failing_two = RecordingChannel(
+        sync_failures=[
+            RuntimeError(
+                "failed https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=wechat-secret-token"
+            )
+        ]
+    )
+    publisher = Publisher([failing_one, failing_two])
+
+    with pytest.raises(NotificationPublishError) as error_info:
+        publisher.publish("hello")
+
+    message = str(error_info.value)
+    assert "bark-secret-token" not in message
+    assert "wechat-secret-token" not in message
+    assert "<redacted>" in message
+
+
 def test_publisher_copies_initial_channel_collection():
     initial_channels = [RecordingChannel()]
     publisher = Publisher(initial_channels)


### PR DESCRIPTION
## Summary

- Add redaction helper for common notification URL secret patterns.
- Redact single-channel failure exception messages while preserving exception type.
- Redact multi-channel `NotificationPublishError` summaries.
- Add regression tests for query-token and path-token leaks.

Closes #21

## Verification

- `uv run --group dev pytest -q tests/test_notification.py -k redacts`
- `uv run --group dev pytest -v tests/test_notification.py`
- `uv run --group dev pytest -v tests`
- `make lint`
