### PR TITLE
fix: avoid optional channel payload pollution

### DIFF
--- a/src/use_notify/channels/bark.py
+++ b/src/use_notify/channels/bark.py
@@ -36,7 +36,7 @@ class Bark(BaseChannel):
 
         # Optional parameters from config
         for param in ["badge", "sound", "icon", "group", "url"]:
-            if hasattr(self.config, param) and getattr(self.config, param) is not None:
+            if param in self.config and getattr(self.config, param) is not None:
                 payload[param] = getattr(self.config, param)
 
         return payload

--- a/src/use_notify/channels/ntfy.py
+++ b/src/use_notify/channels/ntfy.py
@@ -22,14 +22,14 @@ class Ntfy(BaseChannel):
         super().__init__(config)
 
         # 验证必需的配置参数
-        if not hasattr(self.config, "topic") or not self.config.topic:
+        if "topic" not in self.config or not self.config.topic:
             raise ValueError("Ntfy channel requires 'topic' in config")
 
     @property
     def api_url(self):
         """构建 ntfy.sh API URL"""
         # 检查是否有自定义 base_url，否则使用默认值
-        if hasattr(self.config, "base_url") and self.config.base_url:
+        if "base_url" in self.config and self.config.base_url:
             base_url = self.config.base_url.rstrip("/")
         else:
             base_url = "https://ntfy.sh"
@@ -61,23 +61,23 @@ class Ntfy(BaseChannel):
 
         # 添加高级功能支持
         # 优先级支持 (1-5)
-        if hasattr(self.config, "priority") and self.config.priority is not None:
+        if "priority" in self.config and self.config.priority is not None:
             payload["priority"] = self.config.priority
 
         # 标签支持
-        if hasattr(self.config, "tags") and self.config.tags:
+        if "tags" in self.config and self.config.tags:
             payload["tags"] = self.config.tags
 
         # 点击 URL 支持
-        if hasattr(self.config, "click") and self.config.click:
+        if "click" in self.config and self.config.click:
             payload["click"] = self.config.click
 
         # 附件 URL 支持
-        if hasattr(self.config, "attach") and self.config.attach:
+        if "attach" in self.config and self.config.attach:
             payload["attach"] = self.config.attach
 
         # 操作支持
-        if hasattr(self.config, "actions") and self.config.actions:
+        if "actions" in self.config and self.config.actions:
             payload["actions"] = self.config.actions
 
         return payload

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -52,6 +52,24 @@ def test_bark_send_builds_expected_request(mock_client):
     response.raise_for_status.assert_called_once_with()
 
 
+def test_bark_minimal_config_omits_missing_optional_fields():
+    channel = useNotifyChannel.Bark({"token": "token"})
+
+    assert channel._prepare_payload("hello", "title") == {
+        "body": "hello",
+        "title": "title",
+    }
+
+
+def test_bark_preserves_explicit_falsy_optional_values():
+    channel = useNotifyChannel.Bark({"token": "token", "badge": 0})
+
+    assert channel._prepare_payload("hello") == {
+        "body": "hello",
+        "badge": 0,
+    }
+
+
 @patch("httpx.AsyncClient")
 @pytest.mark.asyncio
 async def test_chanify_send_async_builds_expected_request(mock_client):
@@ -168,6 +186,13 @@ def test_wechat_send_rejects_business_error_response(mock_client):
 def test_ntfy_requires_topic_and_builds_payload():
     with pytest.raises(ValueError, match="topic"):
         useNotifyChannel.Ntfy({})
+
+    minimal_channel = useNotifyChannel.Ntfy({"topic": "alerts"})
+    assert minimal_channel.api_url == "https://ntfy.sh/alerts"
+    assert minimal_channel._prepare_payload("hello", "title") == {
+        "message": "hello",
+        "title": "title",
+    }
 
     channel = useNotifyChannel.Ntfy(
         {


### PR DESCRIPTION
## Summary

Fixes `AdDict` missing-key behavior leaking into provider payload construction for Bark and Ntfy.

- Use real mapping membership checks instead of `hasattr(...)` for optional config fields.
- Keep explicit optional values working, including `badge=0` for Bark.
- Add regression coverage for minimal Bark and Ntfy configs so missing optional fields are omitted instead of sent as `{}`.

Closes #30

## Test Coverage

New regression tests:

- `test_bark_minimal_config_omits_missing_optional_fields`
- `test_bark_preserves_explicit_falsy_optional_values`
- Ntfy minimal payload assertion inside `test_ntfy_requires_topic_and_builds_payload`

## Pre-Landing Review

Manual diff review completed. Scope is limited to Bark/Ntfy optional config reads plus regression tests. No unrelated files changed.

## Test plan

- [x] `uv run --group dev pytest -q tests/test_channels.py` — 18 passed, 1 existing pytest-asyncio warning
- [x] `make lint` — passed
- [x] `uv run --group dev pytest -q tests` — 57 passed, 1 existing pytest-asyncio warning
- [x] `uv build` — passed

🤖 Generated with OpenAI Codex
