### PR TITLE
fix: normalize retriable exception sequences

### DIFF
--- a/src/use_notify/notification.py
+++ b/src/use_notify/notification.py
@@ -38,13 +38,20 @@ class RetryConfig:
             raise ValueError("retry_delay must be >= 0")
         if self.retry_backoff <= 0:
             raise ValueError("retry_backoff must be > 0")
+
+        try:
+            retriable_exceptions = tuple(self.retriable_exceptions)
+        except TypeError as exc:
+            raise ValueError("retriable_exceptions must only contain exception types") from exc
+
         invalid_exceptions = [
             exception_type
-            for exception_type in self.retriable_exceptions
+            for exception_type in retriable_exceptions
             if not isinstance(exception_type, type) or not issubclass(exception_type, BaseException)
         ]
         if invalid_exceptions:
             raise ValueError("retriable_exceptions must only contain exception types")
+        object.__setattr__(self, "retriable_exceptions", retriable_exceptions)
 
 
 class NotificationPublishError(RuntimeError):

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -77,6 +77,31 @@ async def test_publisher_retries_retriable_async_failure():
     assert len(channel.async_messages) == 2
 
 
+def test_retry_config_normalizes_retriable_exception_list():
+    retry_config = RetryConfig(retriable_exceptions=[RuntimeError])
+
+    assert retry_config.retriable_exceptions == (RuntimeError,)
+
+
+def test_publisher_retries_retriable_exception_list():
+    channel = RecordingChannel(sync_failures=[RuntimeError("temporary")])
+    publisher = Publisher([channel], max_retries=1, retriable_exceptions=[RuntimeError])
+
+    publisher.publish("hello")
+
+    assert len(channel.sync_messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_publisher_retries_async_retriable_exception_list():
+    channel = RecordingChannel(async_failures=[RuntimeError("temporary")])
+    publisher = Publisher([channel], max_retries=1, retriable_exceptions=[RuntimeError])
+
+    await publisher.publish_async("hello")
+
+    assert len(channel.async_messages) == 2
+
+
 def test_publisher_does_not_retry_non_retriable_failure():
     channel = RecordingChannel(sync_failures=[ValueError("bad config")])
     publisher = Publisher([channel], max_retries=3)


### PR DESCRIPTION
## Summary

Fixes retry configuration accepting list inputs but failing later in `isinstance`.

- Normalize `RetryConfig.retriable_exceptions` to a tuple during dataclass initialization.
- Preserve validation for invalid exception entries and non-iterable values.
- Add sync and async regression tests proving list inputs retry correctly.

Closes #31

## Test Coverage

New regression tests:

- `test_retry_config_normalizes_retriable_exception_list`
- `test_publisher_retries_retriable_exception_list`
- `test_publisher_retries_async_retriable_exception_list`

## Pre-Landing Review

Manual diff review completed. Scope is limited to retry configuration normalization and tests.

## Test plan

- [x] `uv run --group dev pytest -q tests/test_notification.py` — 20 passed, 1 existing pytest-asyncio warning
- [x] `make lint` — passed
- [x] `uv run --group dev pytest -q tests` — 60 passed, 1 existing pytest-asyncio warning
- [x] `uv build` — passed

🤖 Generated with OpenAI Codex
