### PR TITLE
fix: redact custom base url path secrets

### DIFF
--- a/src/use_notify/redaction.py
+++ b/src/use_notify/redaction.py
@@ -9,6 +9,7 @@ _PATH_SECRET_PATTERNS = (
     re.compile(r"(?i)(/open-apis/bot/v2/hook/)[^/?\s)]+"),
     re.compile(r"(?i)(ntfy\.sh/)[^/?\s)]+"),
 )
+_SINGLE_SEGMENT_URL_SECRET_RE = re.compile(r"(?i)(https?://[^/?#\s)]+/)[^/?#\s)]+(?=([?#\s)]|$))")
 
 
 def redact_text(value: str) -> str:
@@ -16,6 +17,7 @@ def redact_text(value: str) -> str:
     redacted = _QUERY_SECRET_RE.sub(rf"\1{SECRET_REPLACEMENT}", value)
     for pattern in _PATH_SECRET_PATTERNS:
         redacted = pattern.sub(rf"\1{SECRET_REPLACEMENT}", redacted)
+    redacted = _SINGLE_SEGMENT_URL_SECRET_RE.sub(rf"\1{SECRET_REPLACEMENT}", redacted)
     return redacted
 
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -8,6 +8,7 @@ import use_notify.notification as notification_module
 from tests.helpers import RecordingChannel, make_http_status_error
 from use_notify import NotificationPublishError, useNotify, useNotifyChannel
 from use_notify.notification import Publisher, RetryConfig
+from use_notify.redaction import redact_text
 
 
 class BlockingSyncChannel(RecordingChannel):
@@ -176,6 +177,26 @@ def test_aggregate_failure_redacts_secrets_from_exception_message():
     assert "bark-secret-token" not in message
     assert "wechat-secret-token" not in message
     assert "<redacted>" in message
+
+
+def test_redacts_custom_base_url_path_secrets():
+    message = (
+        "failed https://bark.example.com/bark-secret-token "
+        "and https://ntfy.example.com/my-secret-topic"
+    )
+
+    redacted = redact_text(message)
+
+    assert "bark-secret-token" not in redacted
+    assert "my-secret-topic" not in redacted
+    assert "https://bark.example.com/<redacted>" in redacted
+    assert "https://ntfy.example.com/<redacted>" in redacted
+
+
+def test_redaction_keeps_multi_segment_urls_visible():
+    message = "docs https://example.com/path/to/page"
+
+    assert redact_text(message) == message
 
 
 def test_publisher_copies_initial_channel_collection():


### PR DESCRIPTION
## Summary

Extends notification exception redaction for custom provider base URLs.

- Keep existing provider-specific query and path redaction behavior.
- Add a single-segment URL path fallback for Bark-style token URLs and Ntfy-style topic URLs on custom hosts.
- Add tests for custom Bark/Ntfy redaction and for preserving multi-segment ordinary URLs.

Closes #32

## Test Coverage

New regression tests:

- `test_redacts_custom_base_url_path_secrets`
- `test_redaction_keeps_multi_segment_urls_visible`

## Pre-Landing Review

Manual diff review completed. Scope is limited to notification secret redaction and regression tests.

## Test plan

- [x] `uv run --group dev pytest -q tests/test_notification.py` — 22 passed, 1 existing pytest-asyncio warning
- [x] `make lint` — passed
- [x] `uv run --group dev pytest -q tests` — 62 passed, 1 existing pytest-asyncio warning
- [x] `uv build` — passed

🤖 Generated with OpenAI Codex
