### PR TITLE
test: expand async channel and decorator coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ target-version = ["py38"]
 [tool.isort]
 profile = "black"
 line_length = 100
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -88,6 +88,28 @@ async def test_chanify_send_async_builds_expected_request(mock_client):
     response.raise_for_status.assert_called_once_with()
 
 
+@patch("httpx.Client")
+def test_chanify_send_builds_expected_request(mock_client):
+    response = _mock_sync_http_response({"res": 0})
+    client = mock_client.return_value.__enter__.return_value
+    client.post.return_value = response
+    channel = useNotifyChannel.Chanify(
+        {
+            "token": "token",
+            "base_url": "https://chanify.example.com/",
+        }
+    )
+
+    channel.send("hello", "title")
+
+    client.post.assert_called_once_with(
+        "https://chanify.example.com/v1/sender/token",
+        data={"text": "title\nhello"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
 def test_ding_build_api_body_includes_mentions():
     channel = useNotifyChannel.Ding(
         {
@@ -122,6 +144,24 @@ def test_ding_send_rejects_business_error_response(mock_client):
         channel.send("hello", "title")
 
 
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_ding_send_async_builds_expected_request(mock_client):
+    response = _mock_async_http_response({"errcode": 0})
+    client = mock_client.return_value.__aenter__.return_value
+    client.post = AsyncMock(return_value=response)
+    channel = useNotifyChannel.Ding({"token": "token"})
+
+    await channel.send_async("hello", "title")
+
+    client.post.assert_awaited_once_with(
+        "https://oapi.dingtalk.com/robot/send?access_token=token",
+        json={"msgtype": "markdown", "markdown": {"title": "title", "text": "hello"}, "at": {}},
+        headers={"Content-Type": "application/json"},
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
 def test_feishu_build_api_body_includes_mentions():
     channel = useNotifyChannel.Feishu(
         {
@@ -149,6 +189,34 @@ def test_feishu_send_rejects_business_error_response(mock_client):
 
     with pytest.raises(RuntimeError, match="feishu.*bad webhook"):
         channel.send("hello", "title")
+
+
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_feishu_send_async_builds_expected_request(mock_client):
+    response = _mock_async_http_response({"code": 0})
+    client = mock_client.return_value.__aenter__.return_value
+    client.post = AsyncMock(return_value=response)
+    channel = useNotifyChannel.Feishu({"token": "token"})
+
+    await channel.send_async("hello", "title")
+
+    client.post.assert_awaited_once_with(
+        "https://open.feishu.cn/open-apis/bot/v2/hook/token",
+        json={
+            "msg_type": "post",
+            "content": {
+                "post": {
+                    "zh_cn": {
+                        "title": "title",
+                        "content": [[{"tag": "text", "text": "hello"}]],
+                    }
+                }
+            },
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    response.raise_for_status.assert_called_once_with()
 
 
 def test_wechat_build_api_body_includes_mentions():
@@ -183,6 +251,24 @@ def test_wechat_send_rejects_business_error_response(mock_client):
         channel.send("hello", "title")
 
 
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_wechat_send_async_builds_expected_request(mock_client):
+    response = _mock_async_http_response({"errcode": 0})
+    client = mock_client.return_value.__aenter__.return_value
+    client.post = AsyncMock(return_value=response)
+    channel = useNotifyChannel.WeChat({"token": "token"})
+
+    await channel.send_async("hello", "title")
+
+    client.post.assert_awaited_once_with(
+        "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=token",
+        json={"markdown": {"content": "## title\n\nhello"}, "msgtype": "markdown"},
+        headers={"Content-Type": "application/json"},
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
 def test_ntfy_requires_topic_and_builds_payload():
     with pytest.raises(ValueError, match="topic"):
         useNotifyChannel.Ntfy({})
@@ -213,6 +299,53 @@ def test_ntfy_requires_topic_and_builds_payload():
     }
 
 
+@patch("httpx.Client")
+def test_ntfy_send_builds_expected_request(mock_client):
+    response = _mock_sync_http_response()
+    client = mock_client.return_value.__enter__.return_value
+    client.post.return_value = response
+    channel = useNotifyChannel.Ntfy(
+        {
+            "topic": "alerts",
+            "base_url": "https://ntfy.example.com/",
+            "attach": "https://example.com/file.txt",
+            "actions": [{"action": "view", "label": "Open", "url": "https://example.com"}],
+        }
+    )
+
+    channel.send("hello", "title")
+
+    client.post.assert_called_once_with(
+        "https://ntfy.example.com/alerts",
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        json={
+            "message": "hello",
+            "title": "title",
+            "attach": "https://example.com/file.txt",
+            "actions": [{"action": "view", "label": "Open", "url": "https://example.com"}],
+        },
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_ntfy_send_async_builds_expected_request(mock_client):
+    response = _mock_async_http_response()
+    client = mock_client.return_value.__aenter__.return_value
+    client.post = AsyncMock(return_value=response)
+    channel = useNotifyChannel.Ntfy({"topic": "alerts"})
+
+    await channel.send_async("hello")
+
+    client.post.assert_awaited_once_with(
+        "https://ntfy.sh/alerts",
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        json={"message": "hello"},
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
 def test_pushdeer_prepare_params_handles_markdown_and_invalid_type(caplog):
     markdown_channel = useNotifyChannel.PushDeer({"token": "token", "type": "markdown"})
     invalid_channel = useNotifyChannel.PushDeer({"token": "token", "type": "unknown"})
@@ -230,6 +363,83 @@ def test_pushdeer_prepare_params_handles_markdown_and_invalid_type(caplog):
 
     assert params["type"] == "markdown"
     assert "Invalid message type" in caplog.text
+
+
+def test_pushdeer_requires_token_for_api_url():
+    channel = useNotifyChannel.PushDeer({})
+
+    with pytest.raises(ValueError, match="pushkey"):
+        _ = channel.api_url
+
+
+def test_pushdeer_api_url_uses_custom_base_url():
+    channel = useNotifyChannel.PushDeer(
+        {
+            "token": "token",
+            "base_url": "https://pushdeer.example.com/",
+        }
+    )
+
+    assert channel.api_url == "https://pushdeer.example.com/message/push"
+
+
+def test_pushdeer_prepare_params_handles_default_title_text_and_image():
+    default_channel = useNotifyChannel.PushDeer({"token": "token"})
+    text_channel = useNotifyChannel.PushDeer({"token": "token", "type": "text"})
+    image_channel = useNotifyChannel.PushDeer({"token": "token", "type": "image"})
+
+    assert default_channel._prepare_params("hello") == {
+        "pushkey": "token",
+        "text": "消息提醒",
+        "type": "markdown",
+        "desp": "hello",
+    }
+    assert text_channel._prepare_params("hello", "title") == {
+        "pushkey": "token",
+        "text": "hello",
+        "type": "text",
+    }
+    assert image_channel._prepare_params("https://example.com/image.png", "title") == {
+        "pushkey": "token",
+        "text": "title",
+        "type": "image",
+        "desp": "https://example.com/image.png",
+    }
+
+
+@patch("httpx.Client")
+def test_pushdeer_send_builds_expected_request(mock_client):
+    response = _mock_sync_http_response({"code": 0})
+    client = mock_client.return_value.__enter__.return_value
+    client.get.return_value = response
+    channel = useNotifyChannel.PushDeer({"token": "token", "type": "text"})
+
+    channel.send("hello", "title")
+
+    client.get.assert_called_once_with(
+        "https://api2.pushdeer.com/message/push",
+        params={"pushkey": "token", "text": "hello", "type": "text"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_pushdeer_send_async_builds_expected_request(mock_client):
+    response = _mock_async_http_response({"code": 0})
+    client = mock_client.return_value.__aenter__.return_value
+    client.get = AsyncMock(return_value=response)
+    channel = useNotifyChannel.PushDeer({"token": "token"})
+
+    await channel.send_async("hello", "title")
+
+    client.get.assert_awaited_once_with(
+        "https://api2.pushdeer.com/message/push",
+        params={"pushkey": "token", "text": "title", "type": "markdown", "desp": "hello"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    response.raise_for_status.assert_called_once_with()
 
 
 @patch("httpx.Client")
@@ -253,6 +463,24 @@ def test_pushover_send_builds_expected_request(mock_client):
     channel.send("hello", "title")
 
     client.post.assert_called_once_with(
+        "https://api.pushover.net/1/messages.json",
+        data={"token": "app", "user": "user", "title": "title", "message": "hello"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_pushover_send_async_builds_expected_request(mock_client):
+    response = _mock_async_http_response({"status": 1})
+    client = mock_client.return_value.__aenter__.return_value
+    client.post = AsyncMock(return_value=response)
+    channel = useNotifyChannel.PushOver({"token": "app", "user": "user"})
+
+    await channel.send_async("hello", "title")
+
+    client.post.assert_awaited_once_with(
         "https://api.pushover.net/1/messages.json",
         data={"token": "app", "user": "user", "title": "title", "message": "hello"},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -284,6 +512,24 @@ def test_bark_send_rejects_business_error_response(mock_client):
 
 @patch("httpx.AsyncClient")
 @pytest.mark.asyncio
+async def test_bark_send_async_builds_expected_request(mock_client):
+    response = _mock_async_http_response({"code": 200})
+    client = mock_client.return_value.__aenter__.return_value
+    client.post = AsyncMock(return_value=response)
+    channel = useNotifyChannel.Bark({"token": "token"})
+
+    await channel.send_async("hello")
+
+    client.post.assert_awaited_once_with(
+        "https://api.day.app/token",
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        json={"body": "hello"},
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+@patch("httpx.AsyncClient")
+@pytest.mark.asyncio
 async def test_chanify_send_async_rejects_business_error_response(mock_client):
     response = _mock_async_http_response({"res": 1, "msg": "invalid token"})
     client = mock_client.return_value.__aenter__.return_value
@@ -298,6 +544,17 @@ def test_console_send_outputs_message(capsys):
     channel = useNotifyChannel.Console()
 
     channel.send("hello", "title")
+
+    output = capsys.readouterr().out
+    assert "title" in output
+    assert "hello" in output
+
+
+@pytest.mark.asyncio
+async def test_console_send_async_outputs_message(capsys):
+    channel = useNotifyChannel.Console()
+
+    await channel.send_async("hello", "title")
 
     output = capsys.readouterr().out
     assert "title" in output

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 
 import pytest
 
@@ -13,6 +14,8 @@ from use_notify import (
     useNotify,
 )
 from use_notify.decorator import NotifyConfigError, NotifyDecorator
+from use_notify.decorator.context import ExecutionContext
+from use_notify.decorator.formatter import MessageFormatter
 from use_notify.decorator.sender import NotificationSender
 
 
@@ -48,6 +51,30 @@ class TestNotifyDecorator:
         assert "执行失败" in channel.sync_messages[0]["content"]
         assert "boom" in channel.sync_messages[0]["content"]
 
+    def test_success_notification_can_be_disabled(self):
+        channel = RecordingChannel()
+        notify_instance = useNotify([channel])
+
+        @notify(notify_instance=notify_instance, notify_on_success=False)
+        def task():
+            return "ok"
+
+        assert task() == "ok"
+        assert channel.sync_messages == []
+
+    def test_error_notification_can_be_disabled(self):
+        channel = RecordingChannel()
+        notify_instance = useNotify([channel])
+
+        @notify(notify_instance=notify_instance, notify_on_error=False)
+        def task():
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            task()
+
+        assert channel.sync_messages == []
+
     @pytest.mark.asyncio
     async def test_async_success_sends_notification(self):
         channel = RecordingChannel()
@@ -62,6 +89,22 @@ class TestNotifyDecorator:
 
         assert result == "async-ok"
         assert "async-ok" in channel.async_messages[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_async_error_sends_notification_and_reraises(self):
+        channel = RecordingChannel()
+        notify_instance = useNotify([channel])
+
+        @notify(notify_instance=notify_instance)
+        async def task():
+            await asyncio.sleep(0)
+            raise RuntimeError("async-boom")
+
+        with pytest.raises(RuntimeError, match="async-boom"):
+            await task()
+
+        assert "执行失败" in channel.async_messages[0]["content"]
+        assert "async-boom" in channel.async_messages[0]["content"]
 
     def test_uses_default_notify_instance(self):
         channel = RecordingChannel()
@@ -121,6 +164,28 @@ class TestNotifyDecorator:
         with pytest.raises(NotifyConfigError):
             NotifyDecorator(retriable_exceptions=["bad"])
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"notify_instance": object()},
+            {"title": 123},
+            {"success_template": 123},
+            {"error_template": 123},
+            {"notify_on_success": "yes"},
+            {"notify_on_error": "yes"},
+            {"include_args": "yes"},
+            {"include_result": "yes"},
+            {"timeout": 0},
+            {"retry_delay": -1},
+            {"retry_backoff": 0},
+            {"retriable_exceptions": RuntimeError},
+            {"notify_on_success": False, "notify_on_error": False},
+        ],
+    )
+    def test_invalid_decorator_configuration_is_rejected(self, kwargs):
+        with pytest.raises(NotifyConfigError):
+            NotifyDecorator(**kwargs)
+
     def test_notification_failures_do_not_break_wrapped_function(self):
         channel = RecordingChannel(sync_failures=[ValueError("broken sender")])
         notify_instance = useNotify([channel])
@@ -131,6 +196,17 @@ class TestNotifyDecorator:
 
         assert task() == "business-result"
         assert len(channel.sync_messages) == 1
+
+    def test_missing_default_instance_warns_once(self, caplog):
+        @notify()
+        def task():
+            return "ok"
+
+        with caplog.at_level("WARNING"):
+            assert task() == "ok"
+            assert task() == "ok"
+
+        assert caplog.text.count("未提供 notify_instance") == 1
 
     def test_default_instance_is_isolated_per_thread(self):
         first_channel = RecordingChannel()
@@ -325,3 +401,38 @@ class TestNotifyDecorator:
         assert elapsed < 0.5, f"函数执行时间 {elapsed:.2f}s 超过预期"
         # 超时应该生效，通知发送失败
         assert len(channel.async_messages) == 0
+
+
+def test_message_formatter_includes_args_result_and_truncates_values():
+    context = ExecutionContext(
+        function_name="job",
+        start_time=datetime.now(),
+        args=("alpha",),
+        kwargs={"count": 2},
+    )
+    context.mark_success({"payload": "x" * 250})
+    formatter = MessageFormatter(
+        success_template="{function_name} {args_str} {kwargs_str} {result_str} {end_time}",
+        include_args=True,
+        include_result=True,
+    )
+
+    message = formatter.format_success_message(context)
+
+    assert message["title"] == "✅ job 执行成功"
+    assert '"alpha"' in message["content"]
+    assert '"count": 2' in message["content"]
+    assert "..." in message["content"]
+    assert "返回结果" in message["content"]
+
+
+def test_message_formatter_safe_serialize_fallbacks():
+    class BrokenRepr:
+        def __repr__(self):
+            raise RuntimeError("cannot represent")
+
+    formatter = MessageFormatter()
+
+    assert formatter._safe_serialize(None) == "None"
+    assert "object object" in formatter._safe_serialize({object(): "value"})
+    assert formatter._safe_serialize({BrokenRepr(): "value"}) == "<无法序列化>"


### PR DESCRIPTION
## Summary

Expands coverage for the modules called out in the audit.

- Adds sync/async request-building tests for HTTP notification channels.
- Adds PushDeer parameter edge cases for token validation, custom base URL, default title, text, markdown, and image payloads.
- Adds decorator tests for success/error notification toggles, async error notifications, missing default instance warning behavior, and configuration validation branches.
- Adds formatter tests for args/result variables, truncation, and serialization fallbacks.
- Sets `pytest-asyncio` mode explicitly to `auto`, removing the default-mode deprecation warning.

Closes #34

## Test Coverage

Coverage improved materially from the audit baseline:

- Baseline before this issue: 81%
- This branch: 94%

Notable module improvements:

- `ntfy.py`: 100%
- `pushdeer.py`: 98%
- `decorator/core.py`: 94%
- `decorator/formatter.py`: 98%
- `chanify.py`: 100%
- `console.py`: 100%

## Pre-Landing Review

Manual diff review completed. This PR only adds tests and pytest configuration; no runtime code changed.

## Test plan

- [x] `uv run --group dev pytest -q tests/test_channels.py` — 32 passed
- [x] `uv run --group dev pytest -q tests/test_decorator.py` — 35 passed
- [x] `make lint` — passed
- [x] `make test` — 95 passed
- [x] `make coverage` — 95 passed, total coverage 94%
- [x] `uv build` — passed

🤖 Generated with OpenAI Codex
