### PR TITLE
docs: align pushdeer default type docs

### DIFF
--- a/src/use_notify/channels/pushdeer.py
+++ b/src/use_notify/channels/pushdeer.py
@@ -13,14 +13,14 @@ class PushDeer(BaseChannel):
     """pushdeer app 消息通知
 
     支持三种消息类型:
-    - text: 纯文本消息 (默认)
+    - text: 纯文本消息
     - image: 图片消息
-    - markdown: Markdown格式消息
+    - markdown: Markdown格式消息 (默认)
 
     配置参数:
     - token: PushDeer的pushkey
     - base_url: 可选，自建PushDeer服务的URL，默认为"https://api2.pushdeer.com"
-    - type: 可选，消息类型，可选值为text、markdown、image，默认为text
+    - type: 可选，消息类型，可选值为text、markdown、image，默认为markdown
     """
 
     @property


### PR DESCRIPTION
## Summary

- Update the `PushDeer` class docstring so it documents `markdown` as the default message type.
- Keep the source docs aligned with the existing implementation and tests.

Closes #42

## Test plan

- [x] `uv run --group dev pytest -q tests/test_channels.py -k pushdeer` (`7 passed`)
- [x] `make lint`
- [x] `make test` (`102 passed`)
- [x] `make coverage` (`94%` total coverage)
- [x] `uv build`
- [x] `uv pip check`
