### PR TITLE
Fix title-less channel payloads

### DIFF
--- a/src/use_notify/channels/chanify.py
+++ b/src/use_notify/channels/chanify.py
@@ -28,7 +28,8 @@ class Chanify(BaseChannel):
 
     @staticmethod
     def build_api_body(content, title=None):
-        return {"text": f"{title}\n{content}"}
+        text = f"{title}\n{content}" if title else content
+        return {"text": text}
 
     def send(self, content, title=None):
         api_body = self.build_api_body(content, title)

--- a/src/use_notify/channels/wechat.py
+++ b/src/use_notify/channels/wechat.py
@@ -21,7 +21,8 @@ class WeChat(BaseChannel):
         return {"Content-Type": "application/json"}
 
     def build_api_body(self, title, content):
-        content = f"## {title}\n\n{content}"
+        if title:
+            content = f"## {title}\n\n{content}"
         api_body = {"markdown": {"content": content}, "msgtype": "markdown"}
 
         if self.config.mentioned_list:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -110,6 +110,12 @@ def test_chanify_send_builds_expected_request(mock_client):
     response.raise_for_status.assert_called_once_with()
 
 
+def test_chanify_omits_title_when_missing():
+    channel = useNotifyChannel.Chanify({"token": "token"})
+
+    assert channel.build_api_body("hello") == {"text": "hello"}
+
+
 def test_ding_build_api_body_includes_mentions():
     channel = useNotifyChannel.Ding(
         {
@@ -236,6 +242,15 @@ def test_wechat_build_api_body_includes_mentions():
             "mentioned_list": ["@all"],
             "mentioned_mobile_list": ["13800000000"],
         },
+        "msgtype": "markdown",
+    }
+
+
+def test_wechat_omits_title_when_missing():
+    channel = useNotifyChannel.WeChat({"token": "token"})
+
+    assert channel.build_api_body(None, "hello") == {
+        "markdown": {"content": "hello"},
         "msgtype": "markdown",
     }
 


### PR DESCRIPTION
## Summary

- omit the title prefix for title-less Chanify payloads
- omit the markdown heading for title-less WeChat payloads
- add regression tests for both channel builders

Closes #46

## Verification

- `make lint`
- `make test`
- `make coverage`
- `uv build`
- `uv pip check`