### PR TITLE
Use explicit channel registry

### DIFF
--- a/src/use_notify/channels/__init__.py
+++ b/src/use_notify/channels/__init__.py
@@ -13,3 +13,21 @@ from .wechat import WeChat
 
 # 兼容wecom
 WeCom = WeChat
+
+CHANNEL_REGISTRY = {
+    "bark": Bark,
+    "chanify": Chanify,
+    "console": Console,
+    "ding": Ding,
+    "email": Email,
+    "feishu": Feishu,
+    "ntfy": Ntfy,
+    "pushdeer": PushDeer,
+    "pushover": PushOver,
+    "wechat": WeChat,
+    "wecom": WeChat,
+}
+
+
+def get_channel_class(name):
+    return CHANNEL_REGISTRY.get(name.lower())

--- a/src/use_notify/notification.py
+++ b/src/use_notify/notification.py
@@ -280,12 +280,7 @@ class Notify(Publisher):
         """
         channels = []
         for channel, cfg in settings.items():
-            # Try to get class by case-insensitive match
-            channel_cls = None
-            for cls_name in dir(channels_models):
-                if cls_name.lower() == channel.lower():
-                    channel_cls = getattr(channels_models, cls_name)
-                    break
+            channel_cls = channels_models.get_channel_class(channel)
             if not channel_cls:
                 raise ValueError(f"Unknown channel {channel}")
             channel = channel_cls(cfg)

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -417,6 +417,15 @@ def test_notify_from_settings_builds_case_insensitive_channels():
     assert isinstance(notify_instance.channels[1], useNotifyChannel.WeCom)
 
 
+def test_notify_from_settings_ignores_unregistered_module_attributes(monkeypatch):
+    monkeypatch.setattr(
+        notification_module.channels_models, "Ghost", useNotifyChannel.Bark, raising=False
+    )
+
+    with pytest.raises(ValueError, match="Unknown channel ghost"):
+        useNotify.from_settings({"ghost": {"token": "x"}})
+
+
 def test_notify_from_settings_rejects_unknown_channel():
     with pytest.raises(ValueError, match="Unknown channel"):
         useNotify.from_settings({"unknown": {"token": "x"}})


### PR DESCRIPTION
## Summary

- add an explicit `CHANNEL_REGISTRY` for supported settings channel names and aliases
- update `Notify.from_settings` to use registry lookup instead of scanning `dir(use_notify.channels)`
- add a regression test proving unregistered module attributes are ignored

Closes #50

## Verification

- `make lint`
- `make test` (`117 passed`)
- `make coverage` (`97%` total)
- `uv build`
- `uv pip check`