### PR TITLE
Enforce coverage gates in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Run lint
         run: make lint
       - name: Run tests
-        run: uv run pytest tests/
+        run: make test
+      - name: Run coverage
+        run: make coverage
       - name: Prune uv cache
         run: uv cache prune --ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ line_length = 100
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.coverage.report]
+fail_under = 95


### PR DESCRIPTION
## Summary

- run `make test` in CI instead of calling pytest directly
- add `make coverage` to the Python matrix workflow
- configure coverage to fail below 95% total coverage

Closes #52

## Verification

- `make lint`
- `make test` (`117 passed`)
- `make coverage` (`97%` total)
- `uv build`
- `uv pip check`