### PR TITLE
Support dynamic channel credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ notify.publish(title="消息标题", content="消息正文")
 
 ```
 
+#### 动态凭据
+
+`token` 等凭据字段可以传入字符串，也可以传入无参数函数。发送时会解析函数返回值，适合把刷新、缓存逻辑放在业务侧：
+
+```python
+useNotifyChannel.Bark({"token": lambda: get_current_bark_token()})
+```
+
+库只负责发送前读取当前凭据，不内置各平台 OAuth 或后台刷新线程。
+
 #### 装饰器使用（推荐）
 
 使用 `@notify` 装饰器可以自动为函数执行发送通知：

--- a/skill-references/channels.md
+++ b/skill-references/channels.md
@@ -155,3 +155,17 @@ useNotifyChannel.Console()
 - Use `PushOver`, not `Pushover`.
 - Use `WeChat` or `WeCom`; both resolve to the same implementation.
 - Use `base_url` for Bark, Chanify, Ntfy, and PushDeer when pointing to self-hosted endpoints.
+
+## Dynamic credentials
+
+Credential fields can be static strings or zero-argument callables. The callable
+is resolved when the channel builds the request, so application code can refresh
+or cache credentials outside `use-notify`:
+
+```python
+useNotifyChannel.Bark({"token": lambda: get_current_bark_token()})
+```
+
+This library does not implement provider-specific OAuth refresh flows, background
+refresh threads, or credential persistence. It only reads the current credential
+value before sending.

--- a/src/use_notify/channels/bark.py
+++ b/src/use_notify/channels/bark.py
@@ -20,7 +20,7 @@ class Bark(BaseChannel):
         else:
             base_url = "https://api.day.app"
 
-        return f"{base_url}/{self.config.token}"
+        return f"{base_url}/{self.resolve_config_value('token')}"
 
     @property
     def headers(self):

--- a/src/use_notify/channels/base.py
+++ b/src/use_notify/channels/base.py
@@ -7,6 +7,10 @@ class BaseChannel(metaclass=ABCMeta):
     def __init__(self, config: dict):
         self.config = AdDict(config)
 
+    def resolve_config_value(self, field):
+        value = getattr(self.config, field)
+        return value() if callable(value) else value
+
     @abstractmethod
     def send(self, content, title=None):
         raise NotImplementedError

--- a/src/use_notify/channels/chanify.py
+++ b/src/use_notify/channels/chanify.py
@@ -20,7 +20,7 @@ class Chanify(BaseChannel):
         else:
             base_url = "https://api.chanify.net"
 
-        return f"{base_url}/v1/sender/{self.config.token}"
+        return f"{base_url}/v1/sender/{self.resolve_config_value('token')}"
 
     @property
     def headers(self):

--- a/src/use_notify/channels/ding.py
+++ b/src/use_notify/channels/ding.py
@@ -16,7 +16,10 @@ class Ding(BaseChannel):
 
     @property
     def api_url(self):
-        return f"https://oapi.dingtalk.com/robot/send?access_token={self.config.token}"
+        return (
+            "https://oapi.dingtalk.com/robot/send"
+            f"?access_token={self.resolve_config_value('token')}"
+        )
 
     @property
     def headers(self):

--- a/src/use_notify/channels/feishu.py
+++ b/src/use_notify/channels/feishu.py
@@ -16,7 +16,7 @@ class Feishu(BaseChannel):
 
     @property
     def api_url(self):
-        return f"https://open.feishu.cn/open-apis/bot/v2/hook/{self.config.token}"
+        return f"https://open.feishu.cn/open-apis/bot/v2/hook/{self.resolve_config_value('token')}"
 
     @property
     def headers(self):

--- a/src/use_notify/channels/ntfy.py
+++ b/src/use_notify/channels/ntfy.py
@@ -34,7 +34,7 @@ class Ntfy(BaseChannel):
         else:
             base_url = "https://ntfy.sh"
 
-        return f"{base_url}/{self.config.topic}"
+        return f"{base_url}/{self.resolve_config_value('topic')}"
 
     @property
     def headers(self):

--- a/src/use_notify/channels/pushdeer.py
+++ b/src/use_notify/channels/pushdeer.py
@@ -59,7 +59,7 @@ class PushDeer(BaseChannel):
                 logger.warning(f"Invalid message type: {msg_type}, fallback to text")
             msg_type = "markdown"
 
-        params = {"pushkey": self.config.token, "text": title, "type": msg_type}
+        params = {"pushkey": self.resolve_config_value("token"), "text": title, "type": msg_type}
 
         # 根据消息类型处理内容
         if msg_type == "text":

--- a/src/use_notify/channels/pushover.py
+++ b/src/use_notify/channels/pushover.py
@@ -22,8 +22,8 @@ class PushOver(BaseChannel):
 
     def build_api_body(self, content, title=None):
         return {
-            "token": self.config.token,
-            "user": self.config.user,
+            "token": self.resolve_config_value("token"),
+            "user": self.resolve_config_value("user"),
             "title": title,
             "message": content,
         }

--- a/src/use_notify/channels/wechat.py
+++ b/src/use_notify/channels/wechat.py
@@ -14,7 +14,10 @@ class WeChat(BaseChannel):
 
     @property
     def api_url(self):
-        return f"https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={self.config.token}"
+        return (
+            "https://qyapi.weixin.qq.com/cgi-bin/webhook/send"
+            f"?key={self.resolve_config_value('token')}"
+        )
 
     @property
     def headers(self):

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -26,6 +26,11 @@ def _mock_async_http_response(json_data=None):
     return response
 
 
+def _credential_provider(*values):
+    values_iter = iter(values)
+    return lambda: next(values_iter)
+
+
 def test_validate_business_response_ignores_non_dict_json_payloads():
     response = _mock_sync_http_response(["ok"])
 
@@ -96,6 +101,13 @@ def test_bark_preserves_explicit_falsy_optional_values():
     }
 
 
+def test_bark_resolves_callable_token_each_time():
+    channel = useNotifyChannel.Bark({"token": _credential_provider("first", "second")})
+
+    assert channel.api_url == "https://api.day.app/first"
+    assert channel.api_url == "https://api.day.app/second"
+
+
 @patch("httpx.AsyncClient")
 @pytest.mark.asyncio
 async def test_chanify_send_async_builds_expected_request(mock_client):
@@ -142,6 +154,13 @@ def test_chanify_omits_title_when_missing():
     assert channel.build_api_body("hello") == {"text": "hello"}
 
 
+def test_chanify_resolves_callable_token_each_time():
+    channel = useNotifyChannel.Chanify({"token": _credential_provider("first", "second")})
+
+    assert channel.api_url == "https://api.chanify.net/v1/sender/first"
+    assert channel.api_url == "https://api.chanify.net/v1/sender/second"
+
+
 def test_ding_build_api_body_includes_mentions():
     channel = useNotifyChannel.Ding(
         {
@@ -163,6 +182,13 @@ def test_ding_build_api_body_includes_mentions():
             "atUserIds": ["user-1"],
         },
     }
+
+
+def test_ding_resolves_callable_token_each_time():
+    channel = useNotifyChannel.Ding({"token": _credential_provider("first", "second")})
+
+    assert channel.api_url == "https://oapi.dingtalk.com/robot/send?access_token=first"
+    assert channel.api_url == "https://oapi.dingtalk.com/robot/send?access_token=second"
 
 
 @patch("httpx.Client")
@@ -210,6 +236,13 @@ def test_feishu_build_api_body_includes_mentions():
     assert {"tag": "text", "text": "hello"} in content
     assert {"tag": "at", "user_id": "all"} in content
     assert {"tag": "at", "user_id": "ou_xxx"} in content
+
+
+def test_feishu_resolves_callable_token_each_time():
+    channel = useNotifyChannel.Feishu({"token": _credential_provider("first", "second")})
+
+    assert channel.api_url == "https://open.feishu.cn/open-apis/bot/v2/hook/first"
+    assert channel.api_url == "https://open.feishu.cn/open-apis/bot/v2/hook/second"
 
 
 @patch("httpx.Client")
@@ -270,6 +303,13 @@ def test_wechat_build_api_body_includes_mentions():
         },
         "msgtype": "markdown",
     }
+
+
+def test_wechat_resolves_callable_token_each_time():
+    channel = useNotifyChannel.WeChat({"token": _credential_provider("first", "second")})
+
+    assert channel.api_url == "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=first"
+    assert channel.api_url == "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=second"
 
 
 def test_wechat_omits_title_when_missing():
@@ -338,6 +378,13 @@ def test_ntfy_requires_topic_and_builds_payload():
         "tags": ["warning"],
         "click": "https://example.com",
     }
+
+
+def test_ntfy_resolves_callable_topic_each_time():
+    channel = useNotifyChannel.Ntfy({"topic": _credential_provider("first", "second")})
+
+    assert channel.api_url == "https://ntfy.sh/first"
+    assert channel.api_url == "https://ntfy.sh/second"
 
 
 @patch("httpx.Client")
@@ -411,6 +458,13 @@ def test_pushdeer_requires_token_for_api_url():
 
     with pytest.raises(ValueError, match="pushkey"):
         _ = channel.api_url
+
+
+def test_pushdeer_resolves_callable_token_each_time():
+    channel = useNotifyChannel.PushDeer({"token": _credential_provider("first", "second")})
+
+    assert channel._prepare_params("hello")["pushkey"] == "first"
+    assert channel._prepare_params("hello")["pushkey"] == "second"
 
 
 def test_pushdeer_api_url_uses_custom_base_url():
@@ -509,6 +563,23 @@ def test_pushover_send_builds_expected_request(mock_client):
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     response.raise_for_status.assert_called_once_with()
+
+
+def test_pushover_resolves_callable_credentials_each_time():
+    channel = useNotifyChannel.PushOver(
+        {
+            "token": _credential_provider("app-1", "app-2"),
+            "user": _credential_provider("user-1", "user-2"),
+        }
+    )
+
+    first_payload = channel.build_api_body("hello")
+    second_payload = channel.build_api_body("hello")
+
+    assert first_payload["token"] == "app-1"
+    assert first_payload["user"] == "user-1"
+    assert second_payload["token"] == "app-2"
+    assert second_payload["user"] == "user-2"
 
 
 @patch("httpx.AsyncClient")

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -417,6 +417,12 @@ def test_notify_from_settings_builds_case_insensitive_channels():
     assert isinstance(notify_instance.channels[1], useNotifyChannel.WeCom)
 
 
+def test_notify_from_settings_preserves_callable_credentials():
+    notify_instance = useNotify.from_settings({"bark": {"token": lambda: "dynamic-token"}})
+
+    assert notify_instance.channels[0].api_url == "https://api.day.app/dynamic-token"
+
+
 def test_notify_from_settings_ignores_unregistered_module_attributes(monkeypatch):
     monkeypatch.setattr(
         notification_module.channels_models, "Ghost", useNotifyChannel.Bark, raising=False


### PR DESCRIPTION
## Summary

- allow channel credential fields to be static values or zero-argument callables
- resolve callable credentials when building provider URLs or request payloads
- cover callable credentials for Bark, Chanify, Ding, Feishu, WeChat, Ntfy, PushDeer, PushOver, and `Notify.from_settings`
- document dynamic credential usage and clarify that provider-specific refresh remains application-owned

Closes #13

## Verification

- `make lint`
- `make test` (`126 passed`)
- `make coverage` (`97%` total)
- `uv build`
- `uv pip check`