### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 0.4.0 - 2026-07-11
+
+### Added
+
+- Support dynamic channel credentials by allowing fields such as `token`, `topic`,
+  and `user` to be zero-argument callables resolved when a request is built.
+- Add CI coverage enforcement with a 95% minimum total coverage threshold.
+- Add explicit channel registry lookup for `Notify.from_settings`.
+
+### Fixed
+
+- Avoid rendering `None` in title-less Chanify and WeChat messages.
+- Align Email async missing-recipient logging with the documented `to_emails`
+  field.
+- Avoid over-redacting ordinary single-segment URLs while still redacting
+  secret-like provider paths.
+- Reject bool values for numeric retry and Email port configuration.
+
+### Tests
+
+- Expand channel, retry, Email, provider response, redaction, and dynamic
+  credential coverage. The suite now runs 126 tests with 97% total coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "use-notify"
-version = "0.3.5"
+version = "0.4.0"
 description = "一个简单可扩展的异步消息通知库"
 readme = "README.md"
 requires-python = ">=3.8,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1736,7 +1736,7 @@ wheels = [
 
 [[package]]
 name = "use-notify"
-version = "0.3.5"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Prepare the 0.4.0 release after the recent feature, reliability, and test coverage work.

- Bump package metadata from 0.3.5 to 0.4.0.
- Add CHANGELOG.md with 0.4.0 release notes.
- Sync uv.lock with the new local package version.

Closes #55

## Release Notes

- Dynamic channel credentials for runtime token/topic/user resolution.
- CI coverage enforcement at 95% minimum total coverage.
- Explicit channel registry lookup for Notify.from_settings.
- Fixes for title-less Chanify/WeChat payloads, Email async logging, URL redaction, and bool numeric config validation.

## Verification

- `make lint`
- `make coverage` (`126 passed`, total coverage `97%`)
- `uv build`
- `uv pip check`
