### PR TITLE
Align README and skill docs with 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,31 @@ notify.publish(title="消息标题", content="消息正文")
 
 #### 动态凭据
 
-`token` 等凭据字段可以传入字符串，也可以传入无参数函数。发送时会解析函数返回值，适合把刷新、缓存逻辑放在业务侧：
+`token`、`topic`、`user` 等凭据字段可以传入字符串，也可以传入无参数函数。发送时会解析函数返回值，适合把刷新、缓存逻辑放在业务侧：
 
 ```python
 useNotifyChannel.Bark({"token": lambda: get_current_bark_token()})
+useNotifyChannel.Ntfy({"topic": lambda: get_current_ntfy_topic()})
+useNotifyChannel.PushOver({
+    "token": lambda: get_current_app_token(),
+    "user": lambda: get_current_user_key(),
+})
 ```
 
 库只负责发送前读取当前凭据，不内置各平台 OAuth 或后台刷新线程。
+
+`useNotify.from_settings(...)` 同样支持动态凭据，并使用内置渠道注册表解析渠道名：
+
+```python
+from use_notify import useNotify
+
+notify = useNotify.from_settings({
+    "bark": {"token": lambda: get_current_bark_token()},
+    "ntfy": {"topic": lambda: get_current_ntfy_topic()},
+})
+```
+
+渠道名大小写不敏感；未知渠道名会抛出 `ValueError`，避免配置拼写错误被静默忽略。
 
 #### 装饰器使用（推荐）
 
@@ -133,7 +151,7 @@ class Custom(useNotifyChannel.BaseChannel):
 #### Agent Skill
 
 - Installable skill package: `SKILL.md` + `skill-references/`
-- Purpose: help AI coding agents generate correct `use-notify` integration snippets, choose channels, and troubleshoot retry/error behavior
+- Purpose: help AI coding agents generate correct `use-notify` integration snippets, choose channels, configure dynamic credentials, and troubleshoot retry/error behavior
 
 #### 特性
 
@@ -142,4 +160,5 @@ class Custom(useNotifyChannel.BaseChannel):
 - 🎯 **装饰器模式**: 使用 `@notify` 装饰器自动化通知
 - 🔧 **高度可扩展**: 轻松添加自定义通知渠道
 - 📱 **多渠道支持**: 支持微信、钉钉、Bark、邮件等多种通知方式
+- 🔐 **动态凭据**: 支持发送前解析 `token`、`topic`、`user` 等凭据字段
 - ⚙️ **灵活配置**: 支持条件通知、自定义模板、默认实例、超时与重试等高级功能

--- a/SKILL.md
+++ b/SKILL.md
@@ -60,9 +60,12 @@ Read only the references needed for the request.
 - Use exact exported names: `useNotify`, `useNotifyChannel`, `notify`, `NotificationPublishError`, `RetryConfig`.
 - Use exact channel class names: `Bark`, `Chanify`, `Console`, `Ding`, `Email`, `Feishu`, `Ntfy`, `PushDeer`, `PushOver`, `WeChat`, `WeCom`.
 - `WeCom` is an alias of `WeChat`.
+- Credential fields can be static strings or zero-argument callables. Common callable fields are `token`, `topic`, and `user`; read `skill-references/channels.md` before generating dynamic credential examples.
+- `useNotify.from_settings(settings)` resolves names through the explicit channel registry, matches keys case-insensitively, and raises `ValueError` for unknown channel keys.
 - Custom channels must implement `send(content, title=None)` and `send_async(content, title=None)`.
 - The decorator parameters are `notify_on_success` and `notify_on_error`, not older variants like `on_success` or `on_failure`.
 - Do not suggest `notify_on_success=False` and `notify_on_error=False` together; current validation rejects that.
+- Do not pass bool values for numeric config. `max_retries=True`, `retry_delay=False`, `retry_backoff=True`, and `Email({"port": True})` are rejected even though Python bool is an int subclass.
 - Default notify instances are scoped to the current execution context, not a process-wide global singleton.
 
 ## Response guidance

--- a/skill-references/channels.md
+++ b/skill-references/channels.md
@@ -160,12 +160,29 @@ useNotifyChannel.Console()
 
 Credential fields can be static strings or zero-argument callables. The callable
 is resolved when the channel builds the request, so application code can refresh
-or cache credentials outside `use-notify`:
+or cache credentials outside `use-notify`.
+
+Common dynamic fields:
+
+- `token` for Bark, Chanify, Ding, Feishu, PushDeer, PushOver, WeChat, and WeCom.
+- `topic` for Ntfy.
+- `user` for PushOver.
 
 ```python
 useNotifyChannel.Bark({"token": lambda: get_current_bark_token()})
+useNotifyChannel.Ntfy({"topic": lambda: get_current_ntfy_topic()})
+useNotifyChannel.PushOver(
+    {
+        "token": lambda: get_current_pushover_app_token(),
+        "user": lambda: get_current_pushover_user_key(),
+    }
+)
 ```
 
 This library does not implement provider-specific OAuth refresh flows, background
 refresh threads, or credential persistence. It only reads the current credential
 value before sending.
+
+`useNotify.from_settings(...)` preserves callable credential values. Channel keys
+are matched case-insensitively through the explicit registry; unknown keys raise
+`ValueError` instead of falling back to module attributes.

--- a/skill-references/quickstart.md
+++ b/skill-references/quickstart.md
@@ -68,14 +68,15 @@ def job():
 
 ## Build from settings
 
-Channel names are matched case-insensitively.
+Channel names are matched case-insensitively through the explicit channel registry.
+Unknown channel keys raise `ValueError`.
 
 ```python
 from use_notify import useNotify
 
 notify = useNotify.from_settings(
     {
-        "bark": {"token": "bark-token"},
+        "bark": {"token": lambda: "bark-token"},
         "wecom": {"token": "wechat-token"},
     }
 )

--- a/skill-references/troubleshooting.md
+++ b/skill-references/troubleshooting.md
@@ -66,6 +66,9 @@ Non-retriable examples include:
 - `max_retries` must be `>= 0`.
 - `retry_delay` must be `>= 0`.
 - `retry_backoff` must be `> 0`.
+- Bool values are rejected for numeric config even though Python treats `bool` as
+  an `int` subclass. Do not use `max_retries=True`, `retry_delay=False`,
+  `retry_backoff=True`, or `Email({"port": True})`.
 - `retriable_exceptions` must contain exception types, not strings or instances.
 - `Email` validates `server`, `port`, `username`, `password`, and `from_email`
   during initialization, then connects and logs in when a message is sent.

--- a/src/use_notify/notification.py
+++ b/src/use_notify/notification.py
@@ -270,7 +270,8 @@ class Notify(Publisher):
         Example:
             settings = {
             ...     "BARK": {"token": "your token"},
-            ...     "DINGTALK": {"access_token": "your access token"},
+            ...     "DING": {"token": "your token"},
+            ...     "NTFY": {"topic": lambda: "alerts"},
             ... }
             notify = Notify.from_settings(settings)
             notify.publish(title="消息标题", content="消息正文")


### PR DESCRIPTION
## Summary

Align README and the installable agent skill docs with the 0.4.0 release behavior.

- Clarify dynamic credential support for `token`, `topic`, and `user` fields.
- Document that `useNotify.from_settings(...)` uses the explicit channel registry, preserves callables, and rejects unknown channel keys.
- Add bool numeric config guardrails for retry settings and Email `port`.
- Fix the `Notify.from_settings` docstring example to use current registry keys.

Closes #57

## Verification

- `make lint`
- `make test` (`126 passed`)
- `make coverage` (`126 passed`, total coverage `97%`)
